### PR TITLE
UI-API-2: add artifact read endpoints

### DIFF
--- a/src/perpfut/api/app.py
+++ b/src/perpfut/api/app.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
+from .routers.dashboard import router as dashboard_router
 from .routers.health import router as health_router
+from .routers.runs import router as runs_router
 
 
 def create_app() -> FastAPI:
@@ -15,4 +17,6 @@ def create_app() -> FastAPI:
         openapi_url="/api/openapi.json",
     )
     app.include_router(health_router, prefix="/api")
+    app.include_router(dashboard_router, prefix="/api")
+    app.include_router(runs_router, prefix="/api")
     return app

--- a/src/perpfut/api/repository.py
+++ b/src/perpfut/api/repository.py
@@ -1,0 +1,127 @@
+"""Read-only artifact access for the operator API."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .schemas import DashboardOverviewResponse, RunSummaryResponse, RunsListResponse
+from ..config import AppConfig
+from ..run_history import list_runs, load_run_manifest, load_run_state
+
+
+class ArtifactError(RuntimeError):
+    """Raised when an artifact exists but cannot be read safely."""
+
+
+def get_runs_dir() -> Path:
+    return AppConfig.from_env().runtime.runs_dir
+
+
+def list_run_summaries(*, mode: str | None = None, limit: int = 10) -> RunsListResponse:
+    items = _collect_run_summaries(get_runs_dir(), mode=mode, limit=limit)
+    return RunsListResponse(items=items, count=len(items))
+
+
+def build_dashboard_overview(*, mode: str, limit: int = 10) -> DashboardOverviewResponse:
+    items = _collect_run_summaries(get_runs_dir(), mode=mode, limit=1)
+    latest_run = items[0] if items else None
+    latest_state = None
+    recent_events: list[dict[str, Any]] = []
+    recent_fills: list[dict[str, Any]] = []
+    recent_positions: list[dict[str, Any]] = []
+
+    if latest_run is not None:
+        run_dir = get_runs_dir() / latest_run.run_id
+        latest_state = load_artifact_document(run_dir.name, "state.json", required=False)
+        recent_events = load_artifact_list(run_dir.name, "events.ndjson", limit=limit, required=False)
+        recent_fills = load_artifact_list(run_dir.name, "fills.ndjson", limit=limit, required=False)
+        recent_positions = load_artifact_list(run_dir.name, "positions.ndjson", limit=limit, required=False)
+
+    return DashboardOverviewResponse(
+        mode=mode,
+        generated_at=datetime.now(timezone.utc),
+        latest_run=latest_run,
+        latest_state=latest_state,
+        recent_events=recent_events,
+        recent_fills=recent_fills,
+        recent_positions=recent_positions,
+    )
+
+
+def load_artifact_document(run_id: str, filename: str, *, required: bool = True) -> dict[str, Any] | None:
+    run_dir = _resolve_run_dir(run_id)
+    path = run_dir / filename
+    if not path.exists():
+        if required:
+            raise FileNotFoundError(path)
+        return None
+    try:
+        if filename == "state.json":
+            return load_run_state(run_dir)
+        if filename == "manifest.json":
+            return load_run_manifest(run_dir)
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ArtifactError(f"invalid artifact: {path}") from exc
+
+
+def load_artifact_list(
+    run_id: str,
+    filename: str,
+    *,
+    limit: int = 50,
+    required: bool = True,
+) -> list[dict[str, Any]]:
+    run_dir = _resolve_run_dir(run_id)
+    path = run_dir / filename
+    if not path.exists():
+        if required:
+            raise FileNotFoundError(path)
+        return []
+    try:
+        lines = [
+            json.loads(line)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ArtifactError(f"invalid artifact: {path}") from exc
+    return list(reversed(lines))[:limit]
+
+
+def _collect_run_summaries(base_dir: Path, *, mode: str | None, limit: int) -> list[RunSummaryResponse]:
+    summaries: list[RunSummaryResponse] = []
+    for run_dir in list_runs(base_dir):
+        manifest_path = run_dir / "manifest.json"
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest = load_run_manifest(run_dir)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if mode is not None and manifest.get("mode") != mode:
+            continue
+        summaries.append(RunSummaryResponse(**_run_summary_dict(run_dir.name, manifest)))
+        if len(summaries) >= limit:
+            break
+    return summaries
+
+
+def _resolve_run_dir(run_id: str) -> Path:
+    run_dir = get_runs_dir() / run_id
+    if not run_dir.exists() or not run_dir.is_dir():
+        raise FileNotFoundError(run_dir)
+    return run_dir
+
+
+def _run_summary_dict(run_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "created_at": manifest.get("created_at"),
+        "mode": manifest.get("mode"),
+        "product_id": manifest.get("product_id"),
+        "resumed_from_run_id": manifest.get("resumed_from_run_id"),
+    }

--- a/src/perpfut/api/routers/dashboard.py
+++ b/src/perpfut/api/routers/dashboard.py
@@ -1,0 +1,21 @@
+"""Overview endpoints for the operator dashboard."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Query
+
+from ..repository import build_dashboard_overview
+from ..schemas import DashboardOverviewResponse
+
+
+router = APIRouter(tags=["dashboard"])
+
+
+@router.get("/dashboard/overview", response_model=DashboardOverviewResponse)
+def read_dashboard_overview(
+    mode: Literal["paper", "live"] = Query(default="paper"),
+    limit: int = Query(default=10, ge=1, le=200),
+) -> DashboardOverviewResponse:
+    return build_dashboard_overview(mode=mode, limit=limit)

--- a/src/perpfut/api/routers/runs.py
+++ b/src/perpfut/api/routers/runs.py
@@ -1,0 +1,76 @@
+"""Run artifact endpoints."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ..repository import ArtifactError, list_run_summaries, load_artifact_document, load_artifact_list
+from ..schemas import ArtifactDocumentResponse, ArtifactListResponse, RunsListResponse
+
+
+router = APIRouter(tags=["runs"])
+
+
+@router.get("/runs", response_model=RunsListResponse)
+def read_runs(
+    mode: Literal["paper", "live"] | None = Query(default=None),
+    limit: int = Query(default=10, ge=1, le=200),
+) -> RunsListResponse:
+    return list_run_summaries(mode=mode, limit=limit)
+
+
+@router.get("/runs/{run_id}/manifest", response_model=ArtifactDocumentResponse)
+def read_run_manifest(run_id: str) -> ArtifactDocumentResponse:
+    return ArtifactDocumentResponse(run_id=run_id, data=_load_document(run_id, "manifest.json"))
+
+
+@router.get("/runs/{run_id}/state", response_model=ArtifactDocumentResponse)
+def read_run_state(run_id: str) -> ArtifactDocumentResponse:
+    return ArtifactDocumentResponse(run_id=run_id, data=_load_document(run_id, "state.json"))
+
+
+@router.get("/runs/{run_id}/events", response_model=ArtifactListResponse)
+def read_run_events(
+    run_id: str,
+    limit: int = Query(default=50, ge=1, le=500),
+) -> ArtifactListResponse:
+    return _build_list_response(run_id, "events.ndjson", limit=limit)
+
+
+@router.get("/runs/{run_id}/fills", response_model=ArtifactListResponse)
+def read_run_fills(
+    run_id: str,
+    limit: int = Query(default=50, ge=1, le=500),
+) -> ArtifactListResponse:
+    return _build_list_response(run_id, "fills.ndjson", limit=limit)
+
+
+@router.get("/runs/{run_id}/positions", response_model=ArtifactListResponse)
+def read_run_positions(
+    run_id: str,
+    limit: int = Query(default=50, ge=1, le=500),
+) -> ArtifactListResponse:
+    return _build_list_response(run_id, "positions.ndjson", limit=limit)
+
+
+def _load_document(run_id: str, filename: str) -> dict:
+    try:
+        data = load_artifact_document(run_id, filename)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"artifact not found: {filename}") from exc
+    except ArtifactError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    assert data is not None
+    return data
+
+
+def _build_list_response(run_id: str, filename: str, *, limit: int) -> ArtifactListResponse:
+    try:
+        items = load_artifact_list(run_id, filename, limit=limit)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"artifact not found: {filename}") from exc
+    except ArtifactError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return ArtifactListResponse(run_id=run_id, items=items, count=len(items))

--- a/src/perpfut/api/schemas.py
+++ b/src/perpfut/api/schemas.py
@@ -23,6 +23,11 @@ class RunSummaryResponse(BaseModel):
     resumed_from_run_id: str | None = None
 
 
+class RunsListResponse(BaseModel):
+    items: list[RunSummaryResponse]
+    count: int
+
+
 class ArtifactDocumentResponse(BaseModel):
     run_id: str
     data: dict[str, Any]

--- a/tests/integration/test_api_runs.py
+++ b/tests/integration/test_api_runs.py
@@ -1,0 +1,128 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from perpfut.api import create_app
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_ndjson(path: Path, items: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(item) for item in items) + "\n", encoding="utf-8")
+
+
+def _make_run(
+    runs_dir: Path,
+    run_id: str,
+    *,
+    mode: str,
+    include_state: bool = True,
+) -> None:
+    run_dir = runs_dir / run_id
+    run_dir.mkdir(parents=True)
+    _write_json(
+        run_dir / "manifest.json",
+        {
+            "run_id": run_id,
+            "created_at": f"{run_id}-created",
+            "mode": mode,
+            "product_id": "BTC-PERP-INTX",
+            "resumed_from_run_id": None,
+        },
+    )
+    if include_state:
+        _write_json(
+            run_dir / "state.json",
+            {
+                "run_id": run_id,
+                "equity_usdc": 10_100.0,
+                "current_position_notional_usdc": 4_200.0,
+            },
+        )
+    _write_ndjson(
+        run_dir / "events.ndjson",
+        [
+            {"event_type": "cycle", "sequence": 1},
+            {"event_type": "cycle", "sequence": 2},
+        ],
+    )
+    _write_ndjson(
+        run_dir / "fills.ndjson",
+        [
+            {"fill_id": "fill-1", "price": 100.0},
+            {"fill_id": "fill-2", "price": 101.0},
+        ],
+    )
+    _write_ndjson(
+        run_dir / "positions.ndjson",
+        [
+            {"position": {"quantity": 0.1}},
+            {"position": {"quantity": 0.2}},
+        ],
+    )
+
+
+def test_runs_endpoint_filters_and_orders_latest_runs(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    _make_run(tmp_path, "20260322T010000000000Z_alpha", mode="paper")
+    _make_run(tmp_path, "20260322T020000000000Z_beta", mode="live")
+    _make_run(tmp_path, "20260322T030000000000Z_gamma", mode="paper")
+    client = TestClient(create_app())
+
+    response = client.get("/api/runs", params={"mode": "paper", "limit": 1})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    assert payload["items"][0]["run_id"] == "20260322T030000000000Z_gamma"
+
+
+def test_dashboard_overview_uses_latest_matching_run_and_newest_first_lists(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    _make_run(tmp_path, "20260322T010000000000Z_alpha", mode="live")
+    _make_run(tmp_path, "20260322T020000000000Z_beta", mode="paper")
+    client = TestClient(create_app())
+
+    response = client.get("/api/dashboard/overview", params={"mode": "paper", "limit": 1})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["latest_run"]["run_id"] == "20260322T020000000000Z_beta"
+    assert payload["latest_state"]["equity_usdc"] == 10_100.0
+    assert payload["recent_events"][0]["sequence"] == 2
+    assert payload["recent_fills"][0]["fill_id"] == "fill-2"
+    assert payload["recent_positions"][0]["position"]["quantity"] == 0.2
+
+
+def test_run_artifact_endpoints_wrap_documents_and_lists(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper")
+    client = TestClient(create_app())
+
+    state_response = client.get(f"/api/runs/{run_id}/state")
+    events_response = client.get(f"/api/runs/{run_id}/events", params={"limit": 1})
+
+    assert state_response.status_code == 200
+    assert state_response.json()["run_id"] == run_id
+    assert state_response.json()["data"]["equity_usdc"] == 10_100.0
+
+    assert events_response.status_code == 200
+    assert events_response.json()["run_id"] == run_id
+    assert events_response.json()["count"] == 1
+    assert events_response.json()["items"][0]["sequence"] == 2
+
+
+def test_missing_state_returns_not_found(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper", include_state=False)
+    client = TestClient(create_app())
+
+    response = client.get(f"/api/runs/{run_id}/state")
+
+    assert response.status_code == 404
+    assert "state.json" in response.json()["detail"]


### PR DESCRIPTION
Closes #14

## Summary
- add read-only API routes for dashboard overview and run artifact inspection
- serve data directly from `runs/` artifacts with stable JSON envelopes
- add integration coverage for latest-run selection, mode filtering, and newest-first lists

## Validation
- python3 -m pytest
- python3 -m ruff check .
- python3 - <<'PY'\nfrom fastapi.testclient import TestClient\nfrom perpfut.api import create_app\nclient = TestClient(create_app())\nprint(client.get("/api/runs").status_code)\nprint(client.get("/api/dashboard/overview").status_code)\nPY