### PR TITLE
UI-WEB-2: build polling dashboard overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ runs/*
 # Node frontend
 apps/web/.next/
 apps/web/node_modules/
+!apps/web/lib/
+!apps/web/lib/**

--- a/apps/web/components/operator-shell.tsx
+++ b/apps/web/components/operator-shell.tsx
@@ -1,14 +1,42 @@
+"use client";
+
 import Link from "next/link";
+import useSWR from "swr";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { buildDashboardMetrics, formatMoney, formatSigned, formatTimestamp } from "@/lib/dashboard-metrics";
+import { fetchJson, type DashboardOverviewResponse, type RunsListResponse } from "@/lib/perpfut-api";
 
 
-type StatCardProps = {
+function Panel({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <section className={`panel ${className}`}>{children}</section>;
+}
+
+function StatCard({
+  label,
+  value,
+  change,
+  tone = "neutral",
+}: {
   label: string;
   value: string;
   change: string;
   tone?: "neutral" | "accent" | "warning";
-};
-
-function StatCard({ label, value, change, tone = "neutral" }: StatCardProps) {
+}) {
   const changeClass =
     tone === "accent"
       ? "text-[var(--accent)]"
@@ -17,16 +45,16 @@ function StatCard({ label, value, change, tone = "neutral" }: StatCardProps) {
         : "text-[var(--muted)]";
 
   return (
-    <div className="panel flex min-h-36 flex-col justify-between p-5">
+    <Panel className="flex min-h-36 flex-col justify-between p-5">
       <div className="flex items-center justify-between text-[11px] uppercase tracking-[0.28em] text-[var(--muted)]">
         <span>{label}</span>
-        <span className="mono text-[10px] text-[var(--border-strong)]">LIVE VIEW</span>
+        <span className="mono text-[10px] text-[var(--border-strong)]">POLL 2S</span>
       </div>
       <div>
         <div className="mono text-3xl font-semibold tracking-tight text-[var(--text)]">{value}</div>
         <div className={`mt-2 text-sm ${changeClass}`}>{change}</div>
       </div>
-    </div>
+    </Panel>
   );
 }
 
@@ -50,7 +78,75 @@ function SectionHeader({
   );
 }
 
+function LoadingPanel({ label }: { label: string }) {
+  return (
+    <Panel className="p-5">
+      <SectionHeader eyebrow={label} title="Loading operator data" />
+      <div className="signal-grid grid h-72 place-items-center border border-[var(--border)] text-sm text-[var(--muted)]">
+        Waiting for the local API proxy.
+      </div>
+    </Panel>
+  );
+}
+
+function ErrorPanel({ message }: { message: string }) {
+  return (
+    <Panel className="p-5">
+      <SectionHeader eyebrow="Connection" title="API unavailable" />
+      <div className="border border-[rgba(255,109,123,0.38)] bg-[rgba(255,109,123,0.08)] p-4 text-sm leading-6 text-[var(--danger)]">
+        {message}
+      </div>
+    </Panel>
+  );
+}
+
+function EmptyPanel() {
+  return (
+    <Panel className="p-5">
+      <SectionHeader eyebrow="Runs" title="No paper runs yet" />
+      <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+        Start a paper run from the CLI for now, then this dashboard will populate from the
+        artifact history under <span className="mono">runs/</span>.
+      </div>
+    </Panel>
+  );
+}
+
+function EventMessage(event: Record<string, unknown>): string {
+  if (typeof event.reason === "string") {
+    return event.reason;
+  }
+  const signal = asRecord(event.signal);
+  if (signal && typeof signal.target_position === "number") {
+    return `target ${signal.target_position.toFixed(2)} / raw ${(signal.raw_value as number | undefined)?.toFixed(4) ?? "--"}`;
+  }
+  return "artifact event";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 export function OperatorShell() {
+  const overview = useSWR<DashboardOverviewResponse>(
+    "/dashboard/overview?mode=paper&limit=24",
+    (path) => fetchJson(path),
+    { refreshInterval: 2_000 }
+  );
+  const runs = useSWR<RunsListResponse>(
+    "/runs?mode=paper&limit=6",
+    (path) => fetchJson(path),
+    { refreshInterval: 2_000 }
+  );
+
+  const overviewData = overview.data;
+  const metrics = overviewData ? buildDashboardMetrics(overviewData) : null;
+  const latestRun = overviewData?.latest_run;
+  const isLoading = overview.isLoading || runs.isLoading;
+  const error = overview.error ?? runs.error;
+
   return (
     <main className="min-h-screen px-4 py-4 text-[var(--text)] sm:px-6 lg:px-8">
       <div className="mx-auto grid max-w-[1680px] gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
@@ -59,8 +155,8 @@ export function OperatorShell() {
             <div className="mono text-[11px] uppercase tracking-[0.34em] text-[var(--accent)]">perpfut</div>
             <div className="mt-3 text-2xl font-semibold tracking-tight">Operator Console</div>
             <p className="mt-3 max-w-xs text-sm leading-6 text-[var(--muted)]">
-              Local-first control surface for paper mode monitoring, run inspection, and future
-              live-readiness workflows.
+              Local-first monitoring for paper execution, artifact inspection, and later operator
+              controls.
             </p>
             <div className="mt-8 space-y-2">
               {["Overview", "Runs", "Paper Control", "Live Readiness"].map((item, index) => (
@@ -82,11 +178,13 @@ export function OperatorShell() {
 
           <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
             <div className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--warning)]">
-              Design Intent
+              Latest Run
             </div>
-            <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
-              Dense, dark, and operational. This shell favors legibility, state visibility, and
-              calm signal over decorative chrome.
+            <div className="mt-3 text-sm text-[var(--text)]">{latestRun?.run_id ?? "No run detected"}</div>
+            <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+              {latestRun
+                ? `${latestRun.mode?.toUpperCase() ?? "UNKNOWN"} · ${latestRun.product_id ?? "Unknown product"}`
+                : "Waiting for the first matching paper artifact set."}
             </p>
           </div>
         </aside>
@@ -98,11 +196,11 @@ export function OperatorShell() {
                 Operator Overview
               </div>
               <h1 className="mt-3 max-w-3xl text-3xl font-semibold tracking-tight">
-                Monitor paper execution with a single-screen command deck.
+                Paper execution monitoring with live artifact polling.
               </h1>
               <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--muted)]">
-                The data wiring lands in later issues. This first pass establishes the visual
-                system, information hierarchy, and operator shell the live dashboard will sit in.
+                This dashboard reads from the Python operator API every two seconds and surfaces
+                latest-run telemetry, recent fills, and cycle-level positioning.
               </p>
             </div>
             <div className="grid gap-2 text-xs uppercase tracking-[0.22em] text-[var(--muted)] sm:grid-cols-3">
@@ -112,118 +210,218 @@ export function OperatorShell() {
               </div>
               <div className="border border-[var(--border)] px-3 py-3">
                 <div className="mono text-[10px] text-[var(--accent)]">Product</div>
-                <div className="mt-2 text-sm text-[var(--text)]">BTC-PERP-INTX</div>
+                <div className="mt-2 text-sm text-[var(--text)]">{latestRun?.product_id ?? "--"}</div>
               </div>
               <div className="border border-[var(--border)] px-3 py-3">
-                <div className="mono text-[10px] text-[var(--accent)]">Status</div>
-                <div className="mt-2 text-sm text-[var(--warning)]">Awaiting API feed</div>
+                <div className="mono text-[10px] text-[var(--accent)]">Updated</div>
+                <div className="mt-2 text-sm text-[var(--text)]">
+                  {overviewData ? formatTimestamp(overviewData.generated_at) : "--"}
+                </div>
               </div>
             </div>
           </header>
 
-          <div className="grid gap-4 xl:grid-cols-4 md:grid-cols-2">
-            <StatCard label="Equity" value="$10,240" change="+2.4% simulated" tone="accent" />
-            <StatCard label="Realized PnL" value="+$184" change="Directionally positive" tone="accent" />
-            <StatCard label="Net Position" value="0.21 BTC" change="Long bias / clipped" />
-            <StatCard label="Risk State" value="Nominal" change="No drawdown halt active" tone="warning" />
-          </div>
+          {error ? <ErrorPanel message={error.message} /> : null}
+          {!error && isLoading ? <LoadingPanel label="Overview" /> : null}
+          {!error && !isLoading && !latestRun ? <EmptyPanel /> : null}
 
-          <div className="grid gap-4 xl:grid-cols-[1.45fr_1fr]">
-            <section className="panel p-5">
-              <SectionHeader eyebrow="Signal" title="Equity And PnL Trajectory" action="placeholder series" />
-              <div className="signal-grid flex h-80 items-end gap-3 overflow-hidden border border-[var(--border)] px-4 py-5">
-                {[24, 32, 29, 41, 46, 44, 52, 61, 64, 73, 70, 82].map((value, index) => (
-                  <div key={value + index} className="flex h-full flex-1 items-end">
-                    <div
-                      className="w-full bg-gradient-to-t from-[rgba(84,191,255,0.95)] to-[rgba(143,214,255,0.15)]"
-                      style={{ height: `${value}%` }}
-                    />
-                  </div>
-                ))}
+          {!error && !isLoading && latestRun && metrics && overviewData ? (
+            <>
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                <StatCard
+                  label="Equity"
+                  value={formatMoney(metrics.equityUsd)}
+                  change={`${metrics.equitySeries.length} cycle points`}
+                  tone="accent"
+                />
+                <StatCard
+                  label="Realized PnL"
+                  value={formatMoney(metrics.realizedPnlUsd)}
+                  change={`${formatSigned(metrics.unrealizedPnlUsd)} unrealized`}
+                  tone="accent"
+                />
+                <StatCard
+                  label="Net Position"
+                  value={metrics.quantity === null ? "--" : `${metrics.quantity.toFixed(4)} base`}
+                  change={`target ${formatSigned(metrics.targetPosition, 3)}`}
+                />
+                <StatCard
+                  label="Signal"
+                  value={formatSigned(metrics.lastSignalRaw, 4)}
+                  change={`${metrics.fillCount} fills / ${metrics.eventCount} events`}
+                  tone="warning"
+                />
               </div>
-            </section>
 
-            <section className="panel p-5">
-              <SectionHeader eyebrow="Positioning" title="Target Versus Current Exposure" />
-              <div className="signal-grid grid h-80 place-items-center border border-[var(--border)] p-6">
-                <div className="relative flex h-64 w-64 items-center justify-center rounded-full border border-[var(--border)]">
-                  <div className="absolute inset-5 rounded-full border border-dashed border-[var(--border)]" />
-                  <div className="absolute inset-10 rounded-full border border-[var(--border)]" />
-                  <div className="absolute h-48 w-[2px] -rotate-12 bg-[rgba(143,214,255,0.18)]" />
-                  <div className="absolute w-52 border-t border-dashed border-[rgba(143,214,255,0.14)]" />
-                  <div className="absolute bottom-7 left-1/2 h-16 w-16 -translate-x-1/2 rounded-full border border-[var(--border-strong)] bg-[rgba(84,191,255,0.12)]" />
-                  <div className="z-10 text-center">
-                    <div className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--accent)]">
-                      Target / Current
-                    </div>
-                    <div className="mt-3 text-4xl font-semibold tracking-tight">0.38 / 0.21</div>
-                    <div className="mt-2 text-sm text-[var(--muted)]">normalized position</div>
+              <div className="grid gap-4 xl:grid-cols-[1.45fr_1fr]">
+                <Panel className="p-5">
+                  <SectionHeader
+                    eyebrow="Signal"
+                    title="Equity And Realized PnL"
+                    action={`${metrics.equitySeries.length} plotted cycles`}
+                  />
+                  <div className="signal-grid h-80 border border-[var(--border)] p-3">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={metrics.equitySeries}>
+                        <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                        <XAxis
+                          dataKey="label"
+                          tick={{ fill: "#90a4bf", fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                        />
+                        <YAxis
+                          tick={{ fill: "#90a4bf", fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                          width={80}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            border: "1px solid rgba(135, 162, 196, 0.22)",
+                            background: "rgba(8, 12, 20, 0.96)",
+                            color: "#ecf4ff",
+                          }}
+                        />
+                        <Line type="monotone" dataKey="equity" stroke="#8fd6ff" strokeWidth={2.5} dot={false} />
+                        <Line
+                          type="monotone"
+                          dataKey="realizedPnl"
+                          stroke="#f1bb67"
+                          strokeWidth={2}
+                          dot={false}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
                   </div>
-                </div>
-              </div>
-            </section>
-          </div>
+                </Panel>
 
-          <div className="grid gap-4 xl:grid-cols-2">
-            <section className="panel p-5">
-              <SectionHeader eyebrow="Execution Tape" title="Recent Fills" action="mocked rows" />
-              <div className="overflow-hidden border border-[var(--border)]">
-                <table className="w-full border-collapse text-left text-sm">
-                  <thead className="bg-[rgba(84,191,255,0.06)] text-[var(--muted)]">
-                    <tr>
-                      {["Time", "Side", "Size", "Price", "Slippage"].map((cell) => (
-                        <th key={cell} className="px-4 py-3 font-medium">
-                          {cell}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="mono">
-                    {[
-                      ["12:01:00", "BUY", "0.024", "70120.2", "+3.0bps"],
-                      ["12:04:00", "BUY", "0.011", "70188.1", "+3.0bps"],
-                      ["12:10:00", "SELL", "0.008", "70302.4", "+3.0bps"],
-                    ].map((row) => (
-                      <tr key={row.join("-")} className="border-t border-[var(--border)] text-[var(--text)]">
-                        {row.map((cell, index) => (
-                          <td
-                            key={cell}
-                            className={`px-4 py-3 ${index === 1 ? "text-[var(--accent)]" : "text-[var(--muted)]"}`}
-                          >
-                            {cell}
-                          </td>
+                <Panel className="p-5">
+                  <SectionHeader
+                    eyebrow="Positioning"
+                    title="Target Versus Current Exposure"
+                    action="derived from cycle artifacts"
+                  />
+                  <div className="signal-grid h-80 border border-[var(--border)] p-3">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={metrics.positionSeries}>
+                        <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                        <XAxis
+                          dataKey="label"
+                          tick={{ fill: "#90a4bf", fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                        />
+                        <YAxis
+                          domain={[-1, 1]}
+                          tick={{ fill: "#90a4bf", fontSize: 11 }}
+                          tickLine={false}
+                          axisLine={false}
+                          width={40}
+                        />
+                        <Tooltip
+                          contentStyle={{
+                            border: "1px solid rgba(135, 162, 196, 0.22)",
+                            background: "rgba(8, 12, 20, 0.96)",
+                            color: "#ecf4ff",
+                          }}
+                        />
+                        <Line type="monotone" dataKey="target" stroke="#8fd6ff" strokeWidth={2.5} dot={false} />
+                        <Line
+                          type="monotone"
+                          dataKey="current"
+                          stroke="#9bf6cf"
+                          strokeWidth={2}
+                          dot={false}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </Panel>
+              </div>
+
+              <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
+                <Panel className="p-5">
+                  <SectionHeader eyebrow="Runs" title="Latest Paper Runs" action={`${runs.data?.count ?? 0} loaded`} />
+                  <div className="overflow-hidden border border-[var(--border)]">
+                    <table className="w-full border-collapse text-left text-sm">
+                      <thead className="bg-[rgba(84,191,255,0.06)] text-[var(--muted)]">
+                        <tr>
+                          {["Run", "Mode", "Product", "Created"].map((cell) => (
+                            <th key={cell} className="px-4 py-3 font-medium">
+                              {cell}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody className="mono">
+                        {(runs.data?.items ?? []).map((run) => (
+                          <tr key={run.run_id} className="border-t border-[var(--border)]">
+                            <td className="px-4 py-3 text-[var(--text)]">{run.run_id}</td>
+                            <td className="px-4 py-3 text-[var(--accent)]">{run.mode ?? "--"}</td>
+                            <td className="px-4 py-3 text-[var(--muted)]">{run.product_id ?? "--"}</td>
+                            <td className="px-4 py-3 text-[var(--muted)]">{formatTimestamp(run.created_at)}</td>
+                          </tr>
                         ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </section>
-
-            <section className="panel p-5">
-              <SectionHeader eyebrow="Events" title="Operator Feed" action="mocked rows" />
-              <div className="space-y-3">
-                {[
-                  ["cycle", "Signal updated to 0.38 target position", "12:10:00"],
-                  ["risk", "Rebalance cleared threshold and minimum notional", "12:10:00"],
-                  ["telemetry", "Run artifacts appended under runs/<timestamp>_<sha>", "12:10:01"],
-                ].map(([tag, message, time]) => (
-                  <div
-                    key={message}
-                    className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-4"
-                  >
-                    <div className="flex items-center justify-between gap-4">
-                      <span className="mono text-[10px] uppercase tracking-[0.26em] text-[var(--accent)]">
-                        {tag}
-                      </span>
-                      <span className="mono text-[11px] text-[var(--muted)]">{time}</span>
-                    </div>
-                    <p className="mt-3 text-sm leading-6 text-[var(--text)]">{message}</p>
+                      </tbody>
+                    </table>
                   </div>
-                ))}
+                </Panel>
+
+                <Panel className="p-5">
+                  <SectionHeader eyebrow="Execution Tape" title="Recent Fills" action={`${overviewData.recent_fills.length} rows`} />
+                  <div className="overflow-hidden border border-[var(--border)]">
+                    <table className="w-full border-collapse text-left text-sm">
+                      <thead className="bg-[rgba(84,191,255,0.06)] text-[var(--muted)]">
+                        <tr>
+                          {["Cycle", "Side", "Qty", "Price"].map((cell) => (
+                            <th key={cell} className="px-4 py-3 font-medium">
+                              {cell}
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody className="mono">
+                        {overviewData.recent_fills.map((row, index) => {
+                          const fill = asRecord(row.fill);
+                          return (
+                            <tr key={`${row.cycle_id ?? "fill"}-${index}`} className="border-t border-[var(--border)]">
+                              <td className="px-4 py-3 text-[var(--muted)]">{String(row.cycle_id ?? "--")}</td>
+                              <td className="px-4 py-3 text-[var(--accent)]">{String(fill?.side ?? "--")}</td>
+                              <td className="px-4 py-3 text-[var(--muted)]">{String(fill?.quantity ?? "--")}</td>
+                              <td className="px-4 py-3 text-[var(--muted)]">{String(fill?.price ?? "--")}</td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </Panel>
               </div>
-            </section>
-          </div>
+
+              <Panel className="p-5">
+                <SectionHeader eyebrow="Events" title="Recent Operator Feed" action={`${overviewData.recent_events.length} rows`} />
+                <div className="grid gap-3 xl:grid-cols-3">
+                  {overviewData.recent_events.slice(0, 6).map((event, index) => (
+                    <div
+                      key={`${String(event.event_type ?? "event")}-${index}`}
+                      className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-4"
+                    >
+                      <div className="flex items-center justify-between gap-4">
+                        <span className="mono text-[10px] uppercase tracking-[0.26em] text-[var(--accent)]">
+                          {String(event.event_type ?? "event")}
+                        </span>
+                        <span className="mono text-[11px] text-[var(--muted)]">
+                          {String(event.cycle_id ?? "--")}
+                        </span>
+                      </div>
+                      <p className="mt-3 text-sm leading-6 text-[var(--text)]">{EventMessage(event)}</p>
+                    </div>
+                  ))}
+                </div>
+              </Panel>
+            </>
+          ) : null}
         </section>
       </div>
     </main>

--- a/apps/web/lib/dashboard-metrics.ts
+++ b/apps/web/lib/dashboard-metrics.ts
@@ -1,0 +1,178 @@
+import type { DashboardOverviewResponse } from "@/lib/perpfut-api";
+
+
+type PositionState = {
+  quantity?: number;
+  mark_price?: number;
+  entry_price?: number | null;
+  collateral_usdc?: number;
+  realized_pnl_usdc?: number;
+};
+
+export type EquityPoint = {
+  label: string;
+  equity: number;
+  realizedPnl: number;
+};
+
+export type PositionPoint = {
+  label: string;
+  target: number;
+  current: number;
+};
+
+export type DashboardMetrics = {
+  equityUsd: number | null;
+  realizedPnlUsd: number | null;
+  unrealizedPnlUsd: number | null;
+  quantity: number | null;
+  targetPosition: number | null;
+  lastSignalRaw: number | null;
+  fillCount: number;
+  eventCount: number;
+  equitySeries: EquityPoint[];
+  positionSeries: PositionPoint[];
+};
+
+const DEFAULT_MAX_ABS_NOTIONAL = 20_000;
+
+export function buildDashboardMetrics(overview: DashboardOverviewResponse): DashboardMetrics {
+  const cycleEvents = overview.recent_events
+    .filter((event) => event.event_type === "cycle")
+    .slice()
+    .reverse();
+
+  let inferredMaxAbsNotional = DEFAULT_MAX_ABS_NOTIONAL;
+  let lastCurrentPosition = 0;
+
+  const equitySeries: EquityPoint[] = [];
+  const positionSeries: PositionPoint[] = [];
+
+  for (const event of cycleEvents) {
+    const signal = asRecord(event.signal);
+    const orderIntent = asRecord(event.order_intent);
+    const position = asRecord(event.position);
+
+    const target = asNumber(signal?.target_position) ?? asNumber(event.target_position) ?? 0;
+    const rawValue = asNumber(signal?.raw_value);
+    const currentNotional = asNumber(orderIntent?.current_notional_usdc);
+    const targetNotional = asNumber(orderIntent?.target_notional_usdc);
+
+    if (targetNotional !== null && target !== 0) {
+      inferredMaxAbsNotional = Math.max(Math.abs(targetNotional / target), 1);
+    }
+
+    if (currentNotional !== null) {
+      lastCurrentPosition = currentNotional / inferredMaxAbsNotional;
+    }
+
+    const positionState = asPositionState(position);
+    const realizedPnl = positionState.realized_pnl_usdc ?? 0;
+    const unrealizedPnl = computeUnrealizedPnl(positionState);
+    const equity = (positionState.collateral_usdc ?? 0) + realizedPnl + unrealizedPnl;
+    const label = String(event.cycle_id ?? event.timestamp ?? event.event_type ?? positionSeries.length + 1);
+
+    equitySeries.push({
+      label,
+      equity,
+      realizedPnl,
+    });
+    positionSeries.push({
+      label,
+      target,
+      current: lastCurrentPosition,
+    });
+
+    if (rawValue !== null) {
+      // no-op: computed again from last cycle below
+    }
+  }
+
+  const latestCycle = cycleEvents.at(-1);
+  const latestSignal = asRecord(latestCycle?.signal);
+  const latestPosition = asPositionState(asRecord(latestCycle?.position));
+  const realizedPnlUsd = latestPosition.realized_pnl_usdc ?? null;
+  const unrealizedPnlUsd = computeUnrealizedPnl(latestPosition);
+  const equityUsd =
+    latestPosition.collateral_usdc !== undefined
+      ? (latestPosition.collateral_usdc ?? 0) + (realizedPnlUsd ?? 0) + unrealizedPnlUsd
+      : null;
+
+  return {
+    equityUsd,
+    realizedPnlUsd,
+    unrealizedPnlUsd,
+    quantity: latestPosition.quantity ?? null,
+    targetPosition: asNumber(latestSignal?.target_position),
+    lastSignalRaw: asNumber(latestSignal?.raw_value),
+    fillCount: overview.recent_fills.length,
+    eventCount: overview.recent_events.length,
+    equitySeries,
+    positionSeries,
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asPositionState(record: Record<string, unknown> | null): PositionState {
+  return {
+    quantity: asOptionalNumber(record?.quantity),
+    mark_price: asOptionalNumber(record?.mark_price),
+    entry_price: asOptionalNumber(record?.entry_price),
+    collateral_usdc: asOptionalNumber(record?.collateral_usdc),
+    realized_pnl_usdc: asOptionalNumber(record?.realized_pnl_usdc),
+  };
+}
+
+function computeUnrealizedPnl(state: PositionState): number {
+  if (
+    state.quantity === undefined ||
+    state.entry_price === undefined ||
+    state.entry_price === null ||
+    state.mark_price === undefined
+  ) {
+    return 0;
+  }
+  return (state.mark_price - state.entry_price) * state.quantity;
+}
+
+function asOptionalNumber(value: unknown): number | undefined {
+  return asNumber(value) ?? undefined;
+}
+
+export function formatMoney(value: number | null): string {
+  if (value === null) {
+    return "--";
+  }
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+export function formatSigned(value: number | null, digits = 2): string {
+  if (value === null) {
+    return "--";
+  }
+  return `${value > 0 ? "+" : ""}${value.toFixed(digits)}`;
+}
+
+export function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return "--";
+  }
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return value;
+  }
+  return new Date(parsed).toLocaleString();
+}

--- a/apps/web/lib/perpfut-api.ts
+++ b/apps/web/lib/perpfut-api.ts
@@ -1,0 +1,34 @@
+export type RunSummary = {
+  run_id: string;
+  created_at: string | null;
+  mode: string | null;
+  product_id: string | null;
+  resumed_from_run_id: string | null;
+};
+
+export type RunsListResponse = {
+  items: RunSummary[];
+  count: number;
+};
+
+export type DashboardOverviewResponse = {
+  mode: "paper" | "live";
+  generated_at: string;
+  latest_run: RunSummary | null;
+  latest_state: Record<string, unknown> | null;
+  recent_events: Record<string, unknown>[];
+  recent_fills: Record<string, unknown>[];
+  recent_positions: Record<string, unknown>[];
+};
+
+const API_BASE = "/api/perpfut";
+
+export async function fetchJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: "/api/perpfut/:path*",
+        destination: `${process.env.PERPFUT_API_ORIGIN ?? "http://127.0.0.1:8000"}/api/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "next": "16.2.1",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "recharts": "3.8.0",
+        "swr": "2.4.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "4.2.2",
@@ -1226,11 +1228,59 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1524,6 +1574,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1559,7 +1672,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1574,6 +1687,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.1",
@@ -2605,6 +2724,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2658,8 +2786,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -2740,6 +2989,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2781,6 +3036,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3026,6 +3290,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -3479,6 +3753,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3936,6 +4216,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3976,6 +4266,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -5458,8 +5757,75 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5504,6 +5870,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -6073,6 +6445,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -6093,6 +6478,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -6429,6 +6820,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "next": "16.2.1",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "recharts": "3.8.0",
+    "swr": "2.4.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.2.2",


### PR DESCRIPTION
Closes #18

## Summary
- replace the static operator shell with a polling dashboard backed by the Python API
- proxy backend traffic through Next via `/api/perpfut/*` rewrites
- add KPI cards, charts, recent runs, fills, and operator-feed views

## Validation
- npm install
- npm run lint
- npm run build
- python3 -m perpfut api --host 127.0.0.1 --port 8000
- npm run dev
- curl -s 'http://127.0.0.1:3000/api/perpfut/dashboard/overview?mode=paper&limit=1' | python3 -m json.tool | sed -n '1,80p'