### PR TITLE
Fix zombie paper process detection

### DIFF
--- a/src/perpfut/api/process_manager.py
+++ b/src/perpfut/api/process_manager.py
@@ -194,12 +194,51 @@ class PaperProcessManager:
 
     def _is_process_alive(self, pid: int) -> bool:
         try:
+            waited_pid, _status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            waited_pid = 0
+        except OSError as exc:
+            raise PaperRunStateError("failed to inspect paper run process state") from exc
+
+        if waited_pid == pid:
+            return False
+
+        process_state = self._get_process_state(pid)
+        if process_state is not None and "Z" in process_state:
+            self._reap_process_if_possible(pid)
+            return False
+
+        try:
             os.kill(pid, 0)
         except ProcessLookupError:
             return False
         except PermissionError:
             return True
         return True
+
+    def _get_process_state(self, pid: int) -> str | None:
+        try:
+            result = subprocess.run(
+                ["ps", "-o", "stat=", "-p", str(pid)],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+        except OSError as exc:
+            raise PaperRunStateError("failed to inspect paper run process state") from exc
+
+        if result.returncode != 0:
+            return None
+        state = result.stdout.strip()
+        return state or None
+
+    def _reap_process_if_possible(self, pid: int) -> None:
+        try:
+            os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            return
+        except OSError as exc:
+            raise PaperRunStateError("failed to reap paper run process") from exc
 
     def _signal_process_group(self, pid: int, sig: signal.Signals) -> None:
         try:

--- a/tests/unit/test_paper_process_manager.py
+++ b/tests/unit/test_paper_process_manager.py
@@ -188,3 +188,49 @@ def test_status_reaps_old_empty_control_lock(monkeypatch, tmp_path) -> None:
 
     assert status.active is False
     assert not lock_path.exists()
+
+
+def test_status_reaps_dead_child_process(monkeypatch, tmp_path) -> None:
+    manager = PaperProcessManager(tmp_path)
+    _write_metadata(tmp_path, pid=4321)
+    metadata_path = tmp_path / "control" / "active_paper.json"
+
+    monkeypatch.setattr("os.waitpid", lambda pid, flags: (pid, 0))
+
+    status = manager.status()
+
+    assert status.active is False
+    assert not metadata_path.exists()
+
+
+def test_stop_succeeds_when_child_is_already_a_zombie(monkeypatch, tmp_path) -> None:
+    manager = PaperProcessManager(tmp_path)
+    _write_metadata(tmp_path, pid=4321)
+    metadata_path = tmp_path / "control" / "active_paper.json"
+    waitpid_results = iter([(0, 0), (4321, 0)])
+
+    monkeypatch.setattr("os.waitpid", lambda pid, flags: next(waitpid_results))
+    monkeypatch.setattr(PaperProcessManager, "_get_process_state", lambda self, pid: None)
+    monkeypatch.setattr(manager, "_signal_process_group", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
+
+    status = manager.stop()
+
+    assert status.active is False
+    assert not metadata_path.exists()
+
+
+def test_status_treats_zombie_process_state_as_inactive(monkeypatch, tmp_path) -> None:
+    manager = PaperProcessManager(tmp_path)
+    _write_metadata(tmp_path, pid=4321)
+    metadata_path = tmp_path / "control" / "active_paper.json"
+    reaped = []
+
+    monkeypatch.setattr("os.waitpid", lambda pid, flags: reaped.append((pid, flags)) or (0, 0))
+    monkeypatch.setattr(PaperProcessManager, "_get_process_state", lambda self, pid: "Z")
+
+    status = manager.status()
+
+    assert status.active is False
+    assert not metadata_path.exists()
+    assert reaped == [(4321, os.WNOHANG), (4321, os.WNOHANG)]


### PR DESCRIPTION
## Summary
- treat zombie paper child processes as dead instead of alive
- reap dead children when possible before reporting status or stop failures
- add regression coverage for zombie and waitpid-based liveness cases

## Testing
- python3 -m pytest tests/unit/test_paper_process_manager.py
- python3 -m ruff check src/perpfut/api/process_manager.py tests/unit/test_paper_process_manager.py

Closes #29