### PR TITLE
Expose decision telemetry in the operator API

### DIFF
--- a/docs/event-schema.md
+++ b/docs/event-schema.md
@@ -23,9 +23,39 @@ Every cycle event should include:
 - `market`
 - `signal`
 - `target_position`
+- `risk_decision`
+- `execution_summary`
+- `no_trade_reason`
 - `order_intent`
 - `fill`
 - `position`
+
+## Decision Fields
+
+`no_trade_reason` is structured for operator and reporting use:
+
+- `code`
+- `message`
+
+`risk_decision` captures the cycle-level risk state:
+
+- `target_before_risk`
+- `target_after_risk`
+- `current_position`
+- `target_notional_usdc`
+- `current_notional_usdc`
+- `delta_notional_usdc`
+- `rebalance_threshold`
+- `min_trade_notional_usdc`
+- `halted`
+- `rebalance_eligible`
+
+`execution_summary` provides the operator-facing cycle outcome:
+
+- `action`
+- `reason_code`
+- `reason_message`
+- `summary`
 
 ## Design Rules
 

--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -53,6 +53,29 @@ Start requests accept:
 
 The service allows only one active paper run at a time.
 
+### Dashboard Overview Shape
+
+`GET /api/dashboard/overview` now returns:
+
+- `latest_run`: newest readable run matching the requested mode
+- `latest_state`: raw latest checkpoint payload for the run
+- `latest_decision`: normalized operator-facing decision summary derived from the latest checkpoint
+- `recent_events`, `recent_fills`, `recent_positions`: newest-first artifact rows
+
+`latest_decision` contains:
+
+- `cycle_id`
+- `mode`
+- `product_id`
+- `signal`
+- `risk_decision`
+- `execution_summary`
+- `no_trade_reason`
+- `order_intent`
+- `fill`
+
+The nested decision objects use the same field names written into run artifacts.
+
 ## Design Notes
 
 - The API does not maintain in-memory trading state for the UI.

--- a/src/perpfut/api/repository.py
+++ b/src/perpfut/api/repository.py
@@ -7,7 +7,16 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .schemas import DashboardOverviewResponse, RunSummaryResponse, RunsListResponse
+from .schemas import (
+    DashboardOverviewResponse,
+    ExecutionSummaryResponse,
+    LatestDecisionResponse,
+    NoTradeReasonResponse,
+    RiskDecisionResponse,
+    RunSummaryResponse,
+    RunsListResponse,
+    SignalDecisionResponse,
+)
 from ..config import AppConfig
 from ..run_history import list_runs, load_run_manifest, load_run_state
 
@@ -45,6 +54,7 @@ def build_dashboard_overview(*, mode: str, limit: int = 10) -> DashboardOverview
         generated_at=datetime.now(timezone.utc),
         latest_run=latest_run,
         latest_state=latest_state,
+        latest_decision=_build_latest_decision(latest_state),
         recent_events=recent_events,
         recent_fills=recent_fills,
         recent_positions=recent_positions,
@@ -125,3 +135,37 @@ def _run_summary_dict(run_id: str, manifest: dict[str, Any]) -> dict[str, Any]:
         "product_id": manifest.get("product_id"),
         "resumed_from_run_id": manifest.get("resumed_from_run_id"),
     }
+
+
+def _build_latest_decision(latest_state: dict[str, Any] | None) -> LatestDecisionResponse | None:
+    if not latest_state:
+        return None
+    signal = _coerce_dict(latest_state.get("signal"))
+    risk_decision = _coerce_dict(latest_state.get("risk_decision"))
+    execution_summary = _coerce_dict(latest_state.get("execution_summary"))
+    no_trade_reason = _coerce_dict(latest_state.get("no_trade_reason"))
+    if not any((signal, risk_decision, execution_summary, no_trade_reason)):
+        return None
+    return LatestDecisionResponse(
+        cycle_id=_coerce_str(latest_state.get("cycle_id")),
+        mode=_coerce_str(latest_state.get("mode")),
+        product_id=_coerce_str(latest_state.get("product_id")),
+        signal=SignalDecisionResponse.model_validate(signal) if signal else None,
+        risk_decision=RiskDecisionResponse.model_validate(risk_decision) if risk_decision else None,
+        execution_summary=(
+            ExecutionSummaryResponse.model_validate(execution_summary)
+            if execution_summary
+            else None
+        ),
+        no_trade_reason=NoTradeReasonResponse.model_validate(no_trade_reason) if no_trade_reason else None,
+        order_intent=_coerce_dict(latest_state.get("order_intent")),
+        fill=_coerce_dict(latest_state.get("fill")),
+    )
+
+
+def _coerce_dict(value: Any) -> dict[str, Any] | None:
+    return value if isinstance(value, dict) else None
+
+
+def _coerce_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None

--- a/src/perpfut/api/schemas.py
+++ b/src/perpfut/api/schemas.py
@@ -39,11 +39,55 @@ class ArtifactListResponse(BaseModel):
     count: int
 
 
+class NoTradeReasonResponse(BaseModel):
+    code: str
+    message: str
+
+
+class RiskDecisionResponse(BaseModel):
+    target_before_risk: float
+    target_after_risk: float
+    current_position: float
+    target_notional_usdc: float
+    current_notional_usdc: float
+    delta_notional_usdc: float
+    rebalance_threshold: float
+    min_trade_notional_usdc: float
+    halted: bool
+    rebalance_eligible: bool
+
+
+class ExecutionSummaryResponse(BaseModel):
+    action: str
+    reason_code: str
+    reason_message: str
+    summary: str
+
+
+class SignalDecisionResponse(BaseModel):
+    strategy: str | None = None
+    raw_value: float | None = None
+    target_position: float | None = None
+
+
+class LatestDecisionResponse(BaseModel):
+    cycle_id: str | None = None
+    mode: str | None = None
+    product_id: str | None = None
+    signal: SignalDecisionResponse | None = None
+    risk_decision: RiskDecisionResponse | None = None
+    execution_summary: ExecutionSummaryResponse | None = None
+    no_trade_reason: NoTradeReasonResponse | None = None
+    order_intent: dict[str, Any] | None = None
+    fill: dict[str, Any] | None = None
+
+
 class DashboardOverviewResponse(BaseModel):
     mode: str
     generated_at: datetime
     latest_run: RunSummaryResponse | None = None
     latest_state: dict[str, Any] | None = None
+    latest_decision: LatestDecisionResponse | None = None
     recent_events: list[dict[str, Any]] = Field(default_factory=list)
     recent_fills: list[dict[str, Any]] = Field(default_factory=list)
     recent_positions: list[dict[str, Any]] = Field(default_factory=list)

--- a/src/perpfut/live_execution.py
+++ b/src/perpfut/live_execution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from dataclasses import replace
 from typing import Protocol
 
 from .config import AppConfig
@@ -171,6 +172,7 @@ class LiveExecutor:
             raw_target_position,
             max_abs_position=self.config.risk.max_abs_position,
         )
+        signal = replace(signal, target_position=target_position)
         target_notional_usdc = target_position * self.config.max_abs_notional_usdc
         delta_notional_usdc = target_notional_usdc - current_notional_usdc
         risk_decision = build_risk_decision(
@@ -217,6 +219,7 @@ class LiveExecutor:
                 exchange_state=exchange_state,
                 current_notional_usdc=current_notional_usdc,
                 current_position=current_position,
+                signal=signal,
                 no_trade_reason=no_trade_reason,
                 risk_decision=risk_decision,
                 execution_summary=execution_summary,
@@ -266,6 +269,7 @@ class LiveExecutor:
                 exchange_state=exchange_state,
                 current_notional_usdc=current_notional_usdc,
                 current_position=current_position,
+                signal=signal,
                 no_trade_reason=no_trade_reason,
                 risk_decision=risk_decision,
                 execution_summary=execution_summary,
@@ -314,6 +318,8 @@ class LiveExecutor:
                 exchange_state=exchange_state,
                 current_notional_usdc=current_notional_usdc,
                 current_position=current_position,
+                signal=signal,
+                order_intent=order_intent,
                 risk_decision=risk_decision,
                 execution_summary=execution_summary,
             )
@@ -359,6 +365,8 @@ class LiveExecutor:
                 exchange_state=exchange_state,
                 current_notional_usdc=current_notional_usdc,
                 current_position=current_position,
+                signal=signal,
+                order_intent=order_intent,
                 risk_decision=risk_decision,
                 execution_summary=execution_summary,
             )
@@ -410,6 +418,8 @@ class LiveExecutor:
             exchange_state=exchange_state,
             current_notional_usdc=current_notional_usdc,
             current_position=current_position,
+            signal=signal,
+            order_intent=order_intent,
             last_submission=submission,
             last_order_status=order_status,
             risk_decision=risk_decision,
@@ -486,6 +496,8 @@ class LiveExecutor:
         exchange_state: IntxReconciliationSnapshot,
         current_notional_usdc: float,
         current_position: float,
+        signal: object | None = None,
+        order_intent: object | None = None,
         last_submission: object | None = None,
         last_order_status: object | None = None,
         no_trade_reason: NoTradeReason | None = None,
@@ -501,6 +513,8 @@ class LiveExecutor:
                 "portfolio_uuid": self.portfolio_uuid,
                 "current_position": current_position,
                 "current_position_notional_usdc": current_notional_usdc,
+                "signal": signal,
+                "order_intent": order_intent,
                 "exchange_snapshot": exchange_state,
                 "no_trade_reason": no_trade_reason,
                 "risk_decision": risk_decision,

--- a/tests/integration/test_api_runs.py
+++ b/tests/integration/test_api_runs.py
@@ -38,8 +38,43 @@ def _make_run(
             run_dir / "state.json",
             {
                 "run_id": run_id,
+                "cycle_id": "cycle-0002",
+                "mode": mode,
+                "product_id": "BTC-PERP-INTX",
                 "equity_usdc": 10_100.0,
                 "current_position_notional_usdc": 4_200.0,
+                "signal": {
+                    "strategy": "momentum",
+                    "raw_value": 0.12,
+                    "target_position": 0.25,
+                },
+                "risk_decision": {
+                    "target_before_risk": 0.25,
+                    "target_after_risk": 0.25,
+                    "current_position": 0.1,
+                    "target_notional_usdc": 5_000.0,
+                    "current_notional_usdc": 2_000.0,
+                    "delta_notional_usdc": 3_000.0,
+                    "rebalance_threshold": 0.1,
+                    "min_trade_notional_usdc": 10.0,
+                    "halted": False,
+                    "rebalance_eligible": True,
+                },
+                "execution_summary": {
+                    "action": "filled",
+                    "reason_code": "filled",
+                    "reason_message": "Cycle placed and filled a rebalance order.",
+                    "summary": "Filled a rebalance order toward the target position.",
+                },
+                "no_trade_reason": None,
+                "order_intent": {
+                    "product_id": "BTC-PERP-INTX",
+                    "side": "BUY",
+                },
+                "fill": {
+                    "product_id": "BTC-PERP-INTX",
+                    "side": "BUY",
+                },
             },
         )
     _write_ndjson(
@@ -92,9 +127,26 @@ def test_dashboard_overview_uses_latest_matching_run_and_newest_first_lists(monk
     payload = response.json()
     assert payload["latest_run"]["run_id"] == "20260322T020000000000Z_beta"
     assert payload["latest_state"]["equity_usdc"] == 10_100.0
+    assert payload["latest_decision"]["cycle_id"] == "cycle-0002"
+    assert payload["latest_decision"]["execution_summary"]["reason_code"] == "filled"
+    assert payload["latest_decision"]["risk_decision"]["rebalance_eligible"] is True
     assert payload["recent_events"][0]["sequence"] == 2
     assert payload["recent_fills"][0]["fill_id"] == "fill-2"
     assert payload["recent_positions"][0]["position"]["quantity"] == 0.2
+
+
+def test_dashboard_overview_exposes_latest_decision_for_live_runs(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    _make_run(tmp_path, "20260322T020000000000Z_beta", mode="live")
+    client = TestClient(create_app())
+
+    response = client.get("/api/dashboard/overview", params={"mode": "live", "limit": 1})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["latest_run"]["mode"] == "live"
+    assert payload["latest_decision"]["mode"] == "live"
+    assert payload["latest_decision"]["signal"]["target_position"] == 0.25
 
 
 def test_run_artifact_endpoints_wrap_documents_and_lists(monkeypatch, tmp_path) -> None:

--- a/tests/integration/test_live_execution.py
+++ b/tests/integration/test_live_execution.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import json
 
 from perpfut.config import AppConfig
 from perpfut.domain import (
@@ -186,6 +187,8 @@ def test_live_executor_previews_submits_and_logs_fill(tmp_path) -> None:
     assert "order_fill" in events
     assert "execution_summary" in events
     assert "risk_decision" in events
+    state = json.loads(store.state_path.read_text(encoding="utf-8"))
+    assert state["signal"]["target_position"] == 0.5
 
 
 def test_live_executor_halts_on_preview_error_without_submit(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- add a normalized `latest_decision` object to dashboard overview responses
- carry live signal/order context into latest state so paper and live runs expose the same operator decision surface
- document the new decision fields in the event schema and operator API docs

## Testing
- python3 -m pytest
- python3 -m ruff check src/perpfut/api/schemas.py src/perpfut/api/repository.py src/perpfut/live_execution.py tests/integration/test_api_runs.py

Closes #32