### PR TITLE
Render operator decision explanations

### DIFF
--- a/apps/web/components/operator-shell.test.tsx
+++ b/apps/web/components/operator-shell.test.tsx
@@ -50,6 +50,43 @@ const overviewResponse = {
   latest_state: {
     equity_usdc: 10125,
   },
+  latest_decision: {
+    cycle_id: "cycle-2",
+    mode: "paper",
+    product_id: "BTC-PERP-INTX",
+    signal: {
+      strategy: "momentum",
+      raw_value: 0.0042,
+      target_position: 0.25,
+    },
+    risk_decision: {
+      target_before_risk: 0.25,
+      target_after_risk: 0.25,
+      current_position: 0.15,
+      target_notional_usdc: 5000,
+      current_notional_usdc: 3000,
+      delta_notional_usdc: 2000,
+      rebalance_threshold: 0.1,
+      min_trade_notional_usdc: 10,
+      halted: false,
+      rebalance_eligible: true,
+    },
+    execution_summary: {
+      action: "filled",
+      reason_code: "filled",
+      reason_message: "Cycle placed and filled a rebalance order.",
+      summary: "Filled a rebalance order toward the target position.",
+    },
+    no_trade_reason: null,
+    order_intent: {
+      product_id: "BTC-PERP-INTX",
+      side: "BUY",
+    },
+    fill: {
+      product_id: "BTC-PERP-INTX",
+      side: "BUY",
+    },
+  },
   recent_events: [
     {
       event_type: "cycle",
@@ -151,6 +188,8 @@ describe("OperatorShell", () => {
 
     expect(await screen.findByText("Start or stop the local paper process")).toBeInTheDocument();
     expect(await screen.findByText("$10,125")).toBeInTheDocument();
+    expect(screen.getByText("Latest Cycle Decision")).toBeInTheDocument();
+    expect(screen.getByText("Filled a rebalance order toward the target position.")).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole("button", { name: "Start Paper Run" }));
 

--- a/apps/web/components/operator-shell.tsx
+++ b/apps/web/components/operator-shell.tsx
@@ -25,6 +25,7 @@ import {
   startPaperRun,
   stopPaperRun,
   type DashboardOverviewResponse,
+  type LatestDecision,
   type PaperRunRequest,
   type PaperRunStatusResponse,
   type RunsListResponse,
@@ -141,6 +142,14 @@ function EmptyPanel({ activeRun }: { activeRun: PaperRunStatusResponse | undefin
 }
 
 function EventMessage(event: Record<string, unknown>): string {
+  const executionSummary = asRecord(event.execution_summary);
+  if (typeof executionSummary?.summary === "string") {
+    return executionSummary.summary;
+  }
+  const noTradeReason = asRecord(event.no_trade_reason);
+  if (typeof noTradeReason?.message === "string") {
+    return noTradeReason.message;
+  }
   if (typeof event.reason === "string") {
     return event.reason;
   }
@@ -149,6 +158,115 @@ function EventMessage(event: Record<string, unknown>): string {
     return `target ${signal.target_position.toFixed(2)} / raw ${(signal.raw_value as number | undefined)?.toFixed(4) ?? "--"}`;
   }
   return "artifact event";
+}
+
+function DecisionTone(action: string | null | undefined): "accent" | "warning" | "danger" {
+  if (action === "filled") {
+    return "accent";
+  }
+  if (action === "halted") {
+    return "danger";
+  }
+  return "warning";
+}
+
+function DecisionBadge({ action }: { action: string | null | undefined }) {
+  const tone = DecisionTone(action);
+  const classes =
+    tone === "accent"
+      ? "border-[rgba(143,214,255,0.36)] bg-[rgba(143,214,255,0.09)] text-[var(--accent)]"
+      : tone === "danger"
+        ? "border-[rgba(255,109,123,0.36)] bg-[rgba(255,109,123,0.08)] text-[var(--danger)]"
+        : "border-[rgba(241,187,103,0.34)] bg-[rgba(241,187,103,0.08)] text-[var(--warning)]";
+
+  return (
+    <span className={`mono inline-flex items-center border px-3 py-2 text-[10px] uppercase tracking-[0.24em] ${classes}`}>
+      {action ?? "unknown"}
+    </span>
+  );
+}
+
+function DecisionValue({
+  label,
+  value,
+  tone = "muted",
+}: {
+  label: string;
+  value: string;
+  tone?: "muted" | "accent" | "warning" | "danger";
+}) {
+  const textClass =
+    tone === "accent"
+      ? "text-[var(--accent)]"
+      : tone === "warning"
+        ? "text-[var(--warning)]"
+      : tone === "danger"
+        ? "text-[var(--danger)]"
+        : "text-[var(--text)]";
+  return (
+    <div className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-4">
+      <div className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">{label}</div>
+      <div className={`mt-3 text-sm leading-6 ${textClass}`}>{value}</div>
+    </div>
+  );
+}
+
+function LatestDecisionPanel({ decision }: { decision: LatestDecision | null }) {
+  const risk = decision?.risk_decision;
+  const execution = decision?.execution_summary;
+  const noTradeReason = decision?.no_trade_reason;
+  const signal = decision?.signal;
+
+  if (!decision || !execution) {
+    return (
+      <Panel className="p-5">
+        <SectionHeader eyebrow="Decision" title="Latest Cycle Decision" action="NO DECISION YET" />
+        <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+          The latest readable run has not produced a normalized decision summary yet.
+        </div>
+      </Panel>
+    );
+  }
+
+  return (
+    <Panel className="p-5">
+      <SectionHeader
+        eyebrow="Decision"
+        title="Latest Cycle Decision"
+        action={decision.cycle_id ?? "latest checkpoint"}
+      />
+
+      <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="text-base font-medium text-[var(--text)]">{execution.summary}</div>
+            <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+              {noTradeReason?.message ?? execution.reason_message}
+            </p>
+          </div>
+          <DecisionBadge action={execution.action} />
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <DecisionValue label="Reason Code" value={execution.reason_code} tone={DecisionTone(execution.action)} />
+        <DecisionValue
+          label="Target After Risk"
+          value={formatSigned(risk?.target_after_risk ?? signal?.target_position ?? null, 4)}
+          tone="accent"
+        />
+        <DecisionValue
+          label="Current Position"
+          value={formatSigned(risk?.current_position ?? null, 4)}
+        />
+        <DecisionValue
+          label="Delta Notional"
+          value={formatMoney(risk?.delta_notional_usdc ?? null)}
+          tone={execution.action === "halted" ? "danger" : "muted"}
+        />
+      </div>
+    </Panel>
+  );
 }
 
 function ControlBanner({ feedback }: { feedback: ControlFeedback }) {
@@ -621,6 +739,8 @@ export function OperatorShell() {
                   tone="warning"
                 />
               </div>
+
+              <LatestDecisionPanel decision={overviewData.latest_decision} />
 
               <div className="grid gap-4 xl:grid-cols-[1.45fr_1fr]">
                 <Panel className="p-5">

--- a/apps/web/components/run-detail.test.tsx
+++ b/apps/web/components/run-detail.test.tsx
@@ -50,6 +50,27 @@ describe("RunDetail", () => {
           run_id: "20260322T020000000000Z_demo",
           data: {
             equity_usdc: 10125,
+            cycle_id: "cycle-2",
+            signal: {
+              strategy: "momentum",
+              raw_value: 0.0042,
+              target_position: 0.25,
+            },
+            risk_decision: {
+              target_after_risk: 0.25,
+              current_position: 0.15,
+              delta_notional_usdc: 2000,
+            },
+            execution_summary: {
+              action: "skipped",
+              reason_code: "below_rebalance_threshold",
+              reason_message: "Delta position 0.0200 is below the rebalance threshold of 0.1000.",
+              summary: "Skipped rebalancing: delta position remained below threshold.",
+            },
+            no_trade_reason: {
+              code: "below_rebalance_threshold",
+              message: "Delta position 0.0200 is below the rebalance threshold of 0.1000.",
+            },
           },
         };
       }
@@ -91,6 +112,9 @@ describe("RunDetail", () => {
             {
               event_type: "cycle",
               cycle_id: "cycle-2",
+              execution_summary: {
+                summary: "Skipped rebalancing: delta position remained below threshold.",
+              },
             },
           ],
         };
@@ -103,6 +127,10 @@ describe("RunDetail", () => {
     expect(await screen.findByText("Run Detail: 20260322T020000000000Z_demo")).toBeInTheDocument();
     expect(screen.getByText("Recent Fill Tape")).toBeInTheDocument();
     expect(screen.getByText("BUY")).toBeInTheDocument();
+    expect(screen.getByText("Latest Decision Snapshot")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Skipped rebalancing: delta position remained below threshold.").length
+    ).toBeGreaterThan(0);
     expect(screen.getByText("Operator Event Stream")).toBeInTheDocument();
   });
 

--- a/apps/web/components/run-detail.tsx
+++ b/apps/web/components/run-detail.tsx
@@ -84,6 +84,134 @@ function extractFillValue(row: Record<string, unknown>, field: string): string {
   return typeof value === "number" ? String(value) : String(value ?? "--");
 }
 
+function decisionTone(action: string | null | undefined): "accent" | "warning" | "danger" {
+  if (action === "filled") {
+    return "accent";
+  }
+  if (action === "halted") {
+    return "danger";
+  }
+  return "warning";
+}
+
+function detailValueClass(tone: "accent" | "warning" | "danger" | "text") {
+  if (tone === "accent") {
+    return "text-[var(--accent)]";
+  }
+  if (tone === "warning") {
+    return "text-[var(--warning)]";
+  }
+  if (tone === "danger") {
+    return "text-[var(--danger)]";
+  }
+  return "text-[var(--text)]";
+}
+
+function DetailMetric({
+  label,
+  value,
+  tone = "text",
+}: {
+  label: string;
+  value: string;
+  tone?: "accent" | "warning" | "danger" | "text";
+}) {
+  return (
+    <div className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-4">
+      <div className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">{label}</div>
+      <div className={`mt-3 text-sm leading-6 ${detailValueClass(tone)}`}>{value}</div>
+    </div>
+  );
+}
+
+function DecisionSnapshot({ stateData }: { stateData: Record<string, unknown> }) {
+  const signal = asRecord(stateData.signal);
+  const riskDecision = asRecord(stateData.risk_decision);
+  const executionSummary = asRecord(stateData.execution_summary);
+  const noTradeReason = asRecord(stateData.no_trade_reason);
+
+  if (!executionSummary) {
+    return (
+      <DetailPanel className="p-5">
+        <DetailHeader eyebrow="Decision" title="Latest Decision Snapshot" />
+        <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+          No normalized decision summary is available in this checkpoint yet.
+        </div>
+      </DetailPanel>
+    );
+  }
+
+  const action = typeof executionSummary.action === "string" ? executionSummary.action : null;
+  const summary =
+    typeof executionSummary.summary === "string"
+      ? executionSummary.summary
+      : "No operator summary available.";
+  const reasonCode =
+    typeof executionSummary.reason_code === "string" ? executionSummary.reason_code : "--";
+  const reasonMessage =
+    typeof noTradeReason?.message === "string"
+      ? noTradeReason.message
+      : typeof executionSummary.reason_message === "string"
+        ? executionSummary.reason_message
+        : "--";
+
+  return (
+    <DetailPanel className="p-5">
+      <DetailHeader eyebrow="Decision" title="Latest Decision Snapshot" action={String(stateData.cycle_id ?? "--")} />
+      <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <div className="text-base font-medium text-[var(--text)]">{summary}</div>
+            <p className="mt-2 text-sm leading-6 text-[var(--muted)]">{reasonMessage}</p>
+          </div>
+          <span
+            className={`mono inline-flex items-center border px-3 py-2 text-[10px] uppercase tracking-[0.24em] ${detailValueClass(decisionTone(action))} ${
+              action === "filled"
+                ? "border-[rgba(143,214,255,0.36)] bg-[rgba(143,214,255,0.09)]"
+                : action === "halted"
+                  ? "border-[rgba(255,109,123,0.36)] bg-[rgba(255,109,123,0.08)]"
+                  : "border-[rgba(241,187,103,0.34)] bg-[rgba(241,187,103,0.08)]"
+            }`}
+          >
+            {action ?? "unknown"}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <DetailMetric label="Reason Code" value={reasonCode} tone={decisionTone(action)} />
+        <DetailMetric
+          label="Target After Risk"
+          value={
+            typeof riskDecision?.target_after_risk === "number"
+              ? riskDecision.target_after_risk.toFixed(4)
+              : typeof signal?.target_position === "number"
+                ? signal.target_position.toFixed(4)
+                : "--"
+          }
+          tone="accent"
+        />
+        <DetailMetric
+          label="Current Position"
+          value={
+            typeof riskDecision?.current_position === "number"
+              ? riskDecision.current_position.toFixed(4)
+              : "--"
+          }
+        />
+        <DetailMetric
+          label="Delta Notional"
+          value={
+            typeof riskDecision?.delta_notional_usdc === "number"
+              ? String(riskDecision.delta_notional_usdc.toFixed(2))
+              : "--"
+          }
+        />
+      </div>
+    </DetailPanel>
+  );
+}
+
 export function RunDetail({ runId }: { runId: string }) {
   const manifest = useSWR<ArtifactDocumentResponse>(
     `/runs/${runId}/manifest`,
@@ -182,6 +310,8 @@ export function RunDetail({ runId }: { runId: string }) {
           </DetailPanel>
         </div>
 
+        <DecisionSnapshot stateData={stateData} />
+
         <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
           <DetailPanel className="p-5">
             <DetailHeader eyebrow="Fills" title="Recent Fill Tape" action={`${fills.data.count} rows`} />
@@ -255,6 +385,14 @@ export function RunDetail({ runId }: { runId: string }) {
                     {String(event.cycle_id ?? "--")}
                   </span>
                 </div>
+                <p className="mt-3 text-sm leading-6 text-[var(--text)]">
+                  {String(
+                    asRecord(event.execution_summary)?.summary ??
+                      asRecord(event.no_trade_reason)?.message ??
+                      event.reason ??
+                      "artifact event"
+                  )}
+                </p>
                 <pre className="mt-3 overflow-x-auto text-xs leading-6 text-[var(--muted)]">
                   {JSON.stringify(event, null, 2)}
                 </pre>

--- a/apps/web/lib/perpfut-api.ts
+++ b/apps/web/lib/perpfut-api.ts
@@ -35,9 +35,53 @@ export type DashboardOverviewResponse = {
   generated_at: string;
   latest_run: RunSummary | null;
   latest_state: Record<string, unknown> | null;
+  latest_decision: LatestDecision | null;
   recent_events: Record<string, unknown>[];
   recent_fills: Record<string, unknown>[];
   recent_positions: Record<string, unknown>[];
+};
+
+export type SignalDecision = {
+  strategy: string | null;
+  raw_value: number | null;
+  target_position: number | null;
+};
+
+export type RiskDecision = {
+  target_before_risk: number;
+  target_after_risk: number;
+  current_position: number;
+  target_notional_usdc: number;
+  current_notional_usdc: number;
+  delta_notional_usdc: number;
+  rebalance_threshold: number;
+  min_trade_notional_usdc: number;
+  halted: boolean;
+  rebalance_eligible: boolean;
+};
+
+export type ExecutionSummary = {
+  action: string;
+  reason_code: string;
+  reason_message: string;
+  summary: string;
+};
+
+export type NoTradeReason = {
+  code: string;
+  message: string;
+};
+
+export type LatestDecision = {
+  cycle_id: string | null;
+  mode: string | null;
+  product_id: string | null;
+  signal: SignalDecision | null;
+  risk_decision: RiskDecision | null;
+  execution_summary: ExecutionSummary | null;
+  no_trade_reason: NoTradeReason | null;
+  order_intent: Record<string, unknown> | null;
+  fill: Record<string, unknown> | null;
 };
 
 export type ArtifactDocumentResponse = {


### PR DESCRIPTION
## Summary
- add explicit latest-decision panels to the overview and run-detail views
- prefer structured execution/no-trade summaries in the operator feed instead of raw-json-only interpretation
- extend frontend API typings and coverage for the new decision surfaces

## Testing
- cd apps/web && npm run test
- cd apps/web && npm run lint
- cd apps/web && npm run build

Closes #33