### PR TITLE
Add visibility regression coverage

### DIFF
--- a/apps/web/components/operator-shell.test.tsx
+++ b/apps/web/components/operator-shell.test.tsx
@@ -284,6 +284,86 @@ describe("OperatorShell", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the empty-decision fallback when the latest run has no decision summary yet", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path.startsWith("/dashboard/overview")) {
+        return {
+          ...overviewResponse,
+          latest_decision: null,
+        };
+      }
+      if (path.startsWith("/runs?")) {
+        return runsResponse;
+      }
+      if (path === "/paper-runs/active") {
+        return {
+          active: false,
+          pid: null,
+          started_at: null,
+          run_id: null,
+          product_id: null,
+          iterations: null,
+          interval_seconds: null,
+          starting_collateral_usdc: null,
+          log_path: null,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderShell();
+
+    expect(await screen.findByText("Latest Cycle Decision")).toBeInTheDocument();
+    expect(
+      screen.getByText("The latest readable run has not produced a normalized decision summary yet.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a halted decision summary from structured reason fields", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path.startsWith("/dashboard/overview")) {
+        return {
+          ...overviewResponse,
+          latest_decision: {
+            ...overviewResponse.latest_decision,
+            execution_summary: {
+              action: "halted",
+              reason_code: "drawdown_halt",
+              reason_message: "Trading halted because the configured daily drawdown limit was breached.",
+              summary: "Trading halted for the cycle because the drawdown guard triggered.",
+            },
+            no_trade_reason: {
+              code: "drawdown_halt",
+              message: "Trading halted because the configured daily drawdown limit was breached.",
+            },
+          },
+        };
+      }
+      if (path.startsWith("/runs?")) {
+        return runsResponse;
+      }
+      if (path === "/paper-runs/active") {
+        return {
+          active: false,
+          pid: null,
+          started_at: null,
+          run_id: null,
+          product_id: null,
+          iterations: null,
+          interval_seconds: null,
+          starting_collateral_usdc: null,
+          log_path: null,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderShell();
+
+    expect(await screen.findByText("Trading halted for the cycle because the drawdown guard triggered.")).toBeInTheDocument();
+    expect(screen.getByText("drawdown_halt")).toBeInTheDocument();
+  });
+
   it("renders an API error panel when polling fails", async () => {
     mockedFetchJson.mockRejectedValue(new ApiError("control plane unavailable", 500));
 

--- a/apps/web/components/run-detail.test.tsx
+++ b/apps/web/components/run-detail.test.tsx
@@ -142,4 +142,41 @@ describe("RunDetail", () => {
     expect(await screen.findByText("Unable to load run artifacts")).toBeInTheDocument();
     expect(screen.getByText("run artifacts unavailable")).toBeInTheDocument();
   });
+
+  it("renders the empty decision fallback for older checkpoints without structured telemetry", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path.endsWith("/manifest")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          data: {
+            mode: "paper",
+            product_id: "BTC-PERP-INTX",
+          },
+        };
+      }
+      if (path.endsWith("/state")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          data: {
+            equity_usdc: 10125,
+          },
+        };
+      }
+      if (path.includes("/fills") || path.includes("/positions") || path.includes("/events")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          count: 0,
+          items: [],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderRunDetail();
+
+    expect(await screen.findByText("Latest Decision Snapshot")).toBeInTheDocument();
+    expect(
+      screen.getByText("No normalized decision summary is available in this checkpoint yet.")
+    ).toBeInTheDocument();
+  });
 });

--- a/tests/integration/test_api_runs.py
+++ b/tests/integration/test_api_runs.py
@@ -168,6 +168,25 @@ def test_run_artifact_endpoints_wrap_documents_and_lists(monkeypatch, tmp_path) 
     assert events_response.json()["items"][0]["sequence"] == 2
 
 
+def test_dashboard_overview_allows_latest_decision_to_be_null_for_older_runs(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_legacy"
+    _make_run(tmp_path, run_id, mode="paper")
+    _write_json(
+        tmp_path / run_id / "state.json",
+        {
+            "run_id": run_id,
+            "equity_usdc": 10_100.0,
+        },
+    )
+    client = TestClient(create_app())
+
+    response = client.get("/api/dashboard/overview", params={"mode": "paper", "limit": 1})
+
+    assert response.status_code == 200
+    assert response.json()["latest_decision"] is None
+
+
 def test_missing_state_returns_not_found(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("RUNS_DIR", str(tmp_path))
     run_id = "20260322T020000000000Z_beta"

--- a/tests/integration/test_paper_engine.py
+++ b/tests/integration/test_paper_engine.py
@@ -86,3 +86,30 @@ def test_paper_engine_records_skip_reason_when_delta_is_below_rebalance_threshol
     assert result.no_trade_reason.code == "below_rebalance_threshold"
     assert result.execution_summary.action == "skipped"
     assert result.risk_decision.rebalance_eligible is False
+
+
+def test_paper_engine_records_skip_reason_when_delta_is_below_min_trade_notional(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("MIN_TRADE_NOTIONAL_USDC", "15000")
+    config = AppConfig.from_env().with_overrides(
+        product_id="BTC-PERP-INTX",
+        iterations=1,
+        interval_seconds=0,
+        runs_dir=tmp_path,
+    )
+    artifact_store = ArtifactStore.create(config.runtime.runs_dir)
+    artifact_store.write_metadata(config)
+    engine = PaperEngine(
+        config=config,
+        market_data=FakeMarketData(),
+        artifact_store=artifact_store,
+    )
+
+    result = engine.run_cycle(1)
+
+    assert result.order_intent is None
+    assert result.no_trade_reason is not None
+    assert result.no_trade_reason.code == "below_min_trade_notional"
+    assert result.execution_summary.reason_code == "below_min_trade_notional"


### PR DESCRIPTION
## Summary
- cover the remaining structured visibility paths in Python and frontend tests
- add minimum-notional skip coverage and legacy-run API fallback coverage
- verify empty-decision and halted-decision UI states explicitly

## Testing
- python3 -m pytest
- cd apps/web && npm run test
- cd apps/web && npm run lint
- cd apps/web && npm run build

Closes #34