### PR TITLE
Add canonical run analysis helpers

### DIFF
--- a/src/perpfut/analysis.py
+++ b/src/perpfut/analysis.py
@@ -1,0 +1,361 @@
+"""Run analysis helpers for canonical performance reporting."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .run_history import load_run_manifest, load_run_state
+
+
+@dataclass(frozen=True, slots=True)
+class SeriesPoint:
+    label: str
+    value: float
+
+
+@dataclass(frozen=True, slots=True)
+class RunAnalysis:
+    run_id: str
+    mode: str | None
+    product_id: str | None
+    strategy_id: str | None
+    started_at: str | None
+    ended_at: str | None
+    cycle_count: int
+    starting_equity_usdc: float
+    ending_equity_usdc: float
+    realized_pnl_usdc: float
+    unrealized_pnl_usdc: float
+    total_pnl_usdc: float
+    total_return_pct: float
+    max_drawdown_usdc: float
+    max_drawdown_pct: float
+    turnover_usdc: float
+    fill_count: int
+    trade_count: int
+    avg_abs_exposure_pct: float
+    max_abs_exposure_pct: float
+    decision_counts: dict[str, int]
+    equity_series: tuple[SeriesPoint, ...]
+    drawdown_series: tuple[SeriesPoint, ...]
+    exposure_series: tuple[SeriesPoint, ...]
+
+
+def analyze_run(run_dir: Path) -> RunAnalysis:
+    manifest = load_run_manifest(run_dir)
+    state = load_run_state(run_dir)
+    config = _load_optional_json(run_dir / "config.json") or {}
+    events = _load_optional_ndjson(run_dir / "events.ndjson")
+    positions = _load_optional_ndjson(run_dir / "positions.ndjson")
+    fills = _collect_fill_rows(run_dir, events)
+
+    max_abs_notional = _resolve_max_abs_notional(config)
+    equity_series = _build_equity_series(positions)
+    if not equity_series:
+        ending_equity = _resolve_ending_equity(state)
+        starting_equity = _resolve_starting_equity(config, ending_equity)
+        equity_series = [SeriesPoint(label="start", value=starting_equity)]
+        if str(state.get("cycle_id") or "latest") != "start" or ending_equity != starting_equity:
+            equity_series.append(
+                SeriesPoint(label=str(state.get("cycle_id") or "latest"), value=ending_equity)
+            )
+    drawdown_series = _build_drawdown_series(equity_series)
+    exposure_series = _build_exposure_series(positions, state, max_abs_notional)
+    decision_counts = _count_decisions(events, state)
+
+    starting_equity = equity_series[0].value
+    ending_equity = equity_series[-1].value
+    total_pnl = ending_equity - starting_equity
+    total_return_pct = (total_pnl / starting_equity) if abs(starting_equity) > 1e-12 else 0.0
+    max_drawdown_usdc = max((point.value for point in drawdown_series), default=0.0)
+    max_drawdown_pct = _compute_max_drawdown_pct(equity_series)
+    avg_abs_exposure_pct = (
+        sum(point.value for point in exposure_series) / len(exposure_series)
+        if exposure_series
+        else 0.0
+    )
+    max_abs_exposure_pct = max((point.value for point in exposure_series), default=0.0)
+
+    return RunAnalysis(
+        run_id=run_dir.name,
+        mode=_as_str(manifest.get("mode")),
+        product_id=_as_str(manifest.get("product_id")),
+        strategy_id=_resolve_strategy_id(manifest, config),
+        started_at=_resolve_started_at(manifest, events),
+        ended_at=_resolve_ended_at(state, events),
+        cycle_count=_count_cycles(events, state, equity_series),
+        starting_equity_usdc=starting_equity,
+        ending_equity_usdc=ending_equity,
+        realized_pnl_usdc=_resolve_realized_pnl(state),
+        unrealized_pnl_usdc=_resolve_unrealized_pnl(state),
+        total_pnl_usdc=total_pnl,
+        total_return_pct=total_return_pct,
+        max_drawdown_usdc=max_drawdown_usdc,
+        max_drawdown_pct=max_drawdown_pct,
+        turnover_usdc=sum(_fill_notional(fill) for fill in fills),
+        fill_count=len(fills),
+        trade_count=len(fills),
+        avg_abs_exposure_pct=avg_abs_exposure_pct,
+        max_abs_exposure_pct=max_abs_exposure_pct,
+        decision_counts=decision_counts,
+        equity_series=tuple(equity_series),
+        drawdown_series=tuple(drawdown_series),
+        exposure_series=tuple(exposure_series),
+    )
+
+
+def _load_optional_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_optional_ndjson(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _resolve_max_abs_notional(config: dict[str, Any]) -> float:
+    simulation = config.get("simulation")
+    if isinstance(simulation, dict):
+        starting_collateral = _as_float(simulation.get("starting_collateral_usdc"))
+        max_leverage = _as_float(simulation.get("max_leverage"))
+        if starting_collateral is not None and max_leverage is not None:
+            return starting_collateral * max_leverage
+    return 1.0
+
+
+def _build_equity_series(positions: list[dict[str, Any]]) -> list[SeriesPoint]:
+    points: list[SeriesPoint] = []
+    for row in positions:
+        position = row.get("position")
+        if not isinstance(position, dict):
+            continue
+        label = str(row.get("cycle_id") or len(points))
+        points.append(SeriesPoint(label=label, value=_position_equity(position)))
+    return points
+
+
+def _build_drawdown_series(equity_series: list[SeriesPoint]) -> list[SeriesPoint]:
+    peak = float("-inf")
+    points: list[SeriesPoint] = []
+    for point in equity_series:
+        peak = max(peak, point.value)
+        points.append(SeriesPoint(label=point.label, value=max(peak - point.value, 0.0)))
+    return points
+
+
+def _compute_max_drawdown_pct(equity_series: list[SeriesPoint]) -> float:
+    peak = float("-inf")
+    max_drawdown_pct = 0.0
+    for point in equity_series:
+        peak = max(peak, point.value)
+        if peak <= 0.0:
+            continue
+        max_drawdown_pct = max(max_drawdown_pct, max(peak - point.value, 0.0) / peak)
+    return max_drawdown_pct
+
+
+def _build_exposure_series(
+    positions: list[dict[str, Any]],
+    state: dict[str, Any],
+    max_abs_notional: float,
+) -> list[SeriesPoint]:
+    points: list[SeriesPoint] = []
+    for row in positions:
+        position = row.get("position")
+        if not isinstance(position, dict):
+            continue
+        quantity = _as_float(position.get("quantity")) or 0.0
+        mark_price = _as_float(position.get("mark_price")) or 0.0
+        label = str(row.get("cycle_id") or len(points))
+        points.append(
+            SeriesPoint(label=label, value=abs((quantity * mark_price) / max_abs_notional))
+        )
+    if points:
+        return points
+    current_position = _as_float(state.get("current_position"))
+    if current_position is not None:
+        return [SeriesPoint(label=str(state.get("cycle_id") or "latest"), value=abs(current_position))]
+    return []
+
+
+def _collect_fill_rows(run_dir: Path, events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    fills_path = run_dir / "fills.ndjson"
+    if fills_path.exists():
+        return _load_optional_ndjson(fills_path)
+
+    rows: list[dict[str, Any]] = []
+    for event in events:
+        fills = event.get("fills")
+        if isinstance(fills, list):
+            rows.extend({"fill": fill} for fill in fills if isinstance(fill, dict))
+    return rows
+
+
+def _count_decisions(events: list[dict[str, Any]], state: dict[str, Any]) -> dict[str, int]:
+    latest_reason_by_cycle: dict[str, str] = {}
+    for event in events:
+        cycle_id = _as_str(event.get("cycle_id"))
+        if cycle_id is None:
+            continue
+        code = _extract_reason_code(event)
+        if code is None:
+            continue
+        latest_reason_by_cycle[cycle_id] = code
+    if latest_reason_by_cycle:
+        counts: dict[str, int] = {}
+        for code in latest_reason_by_cycle.values():
+            counts[code] = counts.get(code, 0) + 1
+        return counts
+    code = _extract_reason_code(state)
+    return {code: 1} if code is not None else {}
+
+
+def _count_cycles(
+    events: list[dict[str, Any]],
+    state: dict[str, Any],
+    equity_series: list[SeriesPoint],
+) -> int:
+    cycle_ids = {
+        cycle_id
+        for cycle_id in (_as_str(event.get("cycle_id")) for event in events)
+        if cycle_id is not None
+    }
+    if cycle_ids:
+        return len(cycle_ids)
+    cycle_id = _as_str(state.get("cycle_id"))
+    if cycle_id is not None:
+        return 1
+    return len(equity_series)
+
+
+def _extract_reason_code(payload: dict[str, Any]) -> str | None:
+    execution_summary = payload.get("execution_summary")
+    if isinstance(execution_summary, dict):
+        reason_code = _as_str(execution_summary.get("reason_code"))
+        if reason_code:
+            return reason_code
+    no_trade_reason = payload.get("no_trade_reason")
+    if isinstance(no_trade_reason, dict):
+        return _as_str(no_trade_reason.get("code"))
+    return None
+
+
+def _resolve_strategy_id(manifest: dict[str, Any], config: dict[str, Any]) -> str | None:
+    strategy_id = _as_str(manifest.get("strategy_id"))
+    if strategy_id:
+        return strategy_id
+    strategy = config.get("strategy")
+    if isinstance(strategy, dict):
+        return _as_str(strategy.get("strategy_id"))
+    return None
+
+
+def _resolve_started_at(manifest: dict[str, Any], events: list[dict[str, Any]]) -> str | None:
+    first_event = next((event for event in events if isinstance(event.get("timestamp"), str)), None)
+    return _as_str((first_event or {}).get("timestamp")) or _as_str(manifest.get("created_at"))
+
+
+def _resolve_ended_at(state: dict[str, Any], events: list[dict[str, Any]]) -> str | None:
+    exchange_snapshot = state.get("exchange_snapshot")
+    if isinstance(exchange_snapshot, dict) and isinstance(exchange_snapshot.get("as_of"), str):
+        return _as_str(exchange_snapshot.get("as_of"))
+    for event in reversed(events):
+        timestamp = _as_str(event.get("timestamp"))
+        if timestamp:
+            return timestamp
+    return None
+
+
+def _resolve_realized_pnl(state: dict[str, Any]) -> float:
+    position = state.get("position")
+    if isinstance(position, dict):
+        return _as_float(position.get("realized_pnl_usdc")) or 0.0
+    return 0.0
+
+
+def _resolve_unrealized_pnl(state: dict[str, Any]) -> float:
+    position = state.get("position")
+    if isinstance(position, dict):
+        return _position_unrealized(position)
+    exchange_snapshot = state.get("exchange_snapshot")
+    if isinstance(exchange_snapshot, dict):
+        summary = exchange_snapshot.get("summary")
+        if isinstance(summary, dict):
+            unrealized = summary.get("unrealized_pnl")
+            if isinstance(unrealized, dict):
+                return _as_float(unrealized.get("value")) or 0.0
+    return 0.0
+
+
+def _resolve_ending_equity(state: dict[str, Any]) -> float:
+    position = state.get("position")
+    if isinstance(position, dict):
+        return _position_equity(position)
+    exchange_snapshot = state.get("exchange_snapshot")
+    if isinstance(exchange_snapshot, dict):
+        summary = exchange_snapshot.get("summary")
+        if isinstance(summary, dict):
+            total_balance = summary.get("total_balance")
+            if isinstance(total_balance, dict):
+                value = _as_float(total_balance.get("value"))
+                if value is not None:
+                    return value
+    equity = _as_float(state.get("equity_usdc"))
+    return equity if equity is not None else 0.0
+
+
+def _resolve_starting_equity(config: dict[str, Any], ending_equity: float) -> float:
+    simulation = config.get("simulation")
+    if isinstance(simulation, dict):
+        starting_collateral = _as_float(simulation.get("starting_collateral_usdc"))
+        if starting_collateral is not None:
+            return starting_collateral
+    return ending_equity
+
+
+def _position_equity(position: dict[str, Any]) -> float:
+    collateral = _as_float(position.get("collateral_usdc")) or 0.0
+    realized = _as_float(position.get("realized_pnl_usdc")) or 0.0
+    return collateral + realized + _position_unrealized(position)
+
+
+def _position_unrealized(position: dict[str, Any]) -> float:
+    quantity = _as_float(position.get("quantity"))
+    entry_price = _as_float(position.get("entry_price"))
+    mark_price = _as_float(position.get("mark_price"))
+    if quantity is None or entry_price is None or mark_price is None:
+        return 0.0
+    return (mark_price - entry_price) * quantity
+
+
+def _fill_notional(row: dict[str, Any]) -> float:
+    fill = row.get("fill") if isinstance(row.get("fill"), dict) else row
+    if not isinstance(fill, dict):
+        return 0.0
+    quantity = _as_float(fill.get("quantity"))
+    if quantity is None:
+        quantity = _as_float(fill.get("size"))
+    price = _as_float(fill.get("price"))
+    if quantity is None or price is None:
+        return 0.0
+    return abs(quantity * price)
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _as_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -1,0 +1,183 @@
+import json
+from pathlib import Path
+
+from perpfut.analysis import analyze_run
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_ndjson(path: Path, items: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(item) for item in items) + "\n", encoding="utf-8")
+
+
+def test_analyze_run_computes_canonical_metrics_for_paper_artifacts(tmp_path) -> None:
+    run_dir = tmp_path / "20260322T020000000000Z_demo"
+    run_dir.mkdir(parents=True)
+    _write_json(
+        run_dir / "manifest.json",
+        {
+            "run_id": run_dir.name,
+            "created_at": "2026-03-22T02:00:00Z",
+            "mode": "paper",
+            "product_id": "BTC-PERP-INTX",
+        },
+    )
+    _write_json(
+        run_dir / "config.json",
+        {
+            "simulation": {
+                "starting_collateral_usdc": 10000.0,
+                "max_leverage": 2.0,
+            }
+        },
+    )
+    _write_ndjson(
+        run_dir / "positions.ndjson",
+        [
+            {
+                "cycle_id": "cycle-0001",
+                "position": {
+                    "quantity": 0.0,
+                    "entry_price": None,
+                    "mark_price": 100.0,
+                    "collateral_usdc": 10000.0,
+                    "realized_pnl_usdc": 0.0,
+                },
+            },
+            {
+                "cycle_id": "cycle-0002",
+                "position": {
+                    "quantity": 1.0,
+                    "entry_price": 100.0,
+                    "mark_price": 90.0,
+                    "collateral_usdc": 10000.0,
+                    "realized_pnl_usdc": 0.0,
+                },
+            },
+            {
+                "cycle_id": "cycle-0003",
+                "position": {
+                    "quantity": 1.0,
+                    "entry_price": 100.0,
+                    "mark_price": 115.0,
+                    "collateral_usdc": 10000.0,
+                    "realized_pnl_usdc": 50.0,
+                },
+            },
+        ],
+    )
+    _write_ndjson(
+        run_dir / "fills.ndjson",
+        [
+            {"fill": {"quantity": 1.0, "price": 100.0}},
+            {"fill": {"quantity": 0.5, "price": 110.0}},
+        ],
+    )
+    _write_ndjson(
+        run_dir / "events.ndjson",
+        [
+            {"cycle_id": "cycle-0001", "timestamp": "2026-03-22T02:01:00Z", "execution_summary": {"reason_code": "below_rebalance_threshold"}},
+            {"cycle_id": "cycle-0002", "timestamp": "2026-03-22T02:02:00Z", "execution_summary": {"reason_code": "filled"}},
+            {"cycle_id": "cycle-0003", "timestamp": "2026-03-22T02:03:00Z", "execution_summary": {"reason_code": "filled"}},
+        ],
+    )
+    _write_json(
+        run_dir / "state.json",
+        {
+            "run_id": run_dir.name,
+            "cycle_id": "cycle-0003",
+            "position": {
+                "quantity": 1.0,
+                "entry_price": 100.0,
+                "mark_price": 115.0,
+                "collateral_usdc": 10000.0,
+                "realized_pnl_usdc": 50.0,
+            },
+        },
+    )
+
+    analysis = analyze_run(run_dir)
+
+    assert analysis.run_id == run_dir.name
+    assert analysis.mode == "paper"
+    assert analysis.starting_equity_usdc == 10000.0
+    assert analysis.ending_equity_usdc == 10065.0
+    assert analysis.total_pnl_usdc == 65.0
+    assert analysis.turnover_usdc == 155.0
+    assert analysis.fill_count == 2
+    assert analysis.trade_count == 2
+    assert analysis.decision_counts == {"below_rebalance_threshold": 1, "filled": 2}
+    assert analysis.max_drawdown_usdc == 10.0
+    assert analysis.max_drawdown_pct == 0.001
+    assert round(analysis.avg_abs_exposure_pct, 4) == round((0.0 + 0.0045 + 0.00575) / 3, 4)
+
+
+def test_analyze_run_uses_live_state_fallbacks_when_positions_and_fills_are_absent(tmp_path) -> None:
+    run_dir = tmp_path / "20260322T020000000000Z_live"
+    run_dir.mkdir(parents=True)
+    _write_json(
+        run_dir / "manifest.json",
+        {
+            "run_id": run_dir.name,
+            "created_at": "2026-03-22T02:00:00Z",
+            "mode": "live",
+            "product_id": "BTC-PERP-INTX",
+        },
+    )
+    _write_json(
+        run_dir / "config.json",
+        {
+            "simulation": {
+                "starting_collateral_usdc": 10000.0,
+                "max_leverage": 2.0,
+            }
+        },
+    )
+    _write_json(
+        run_dir / "state.json",
+        {
+            "run_id": run_dir.name,
+            "cycle_id": "cycle-0001",
+            "current_position": 0.2,
+            "execution_summary": {"reason_code": "filled"},
+            "exchange_snapshot": {
+                "as_of": "2026-03-22T02:05:00Z",
+                "summary": {
+                    "total_balance": {"value": 10125.0},
+                    "unrealized_pnl": {"value": 25.0},
+                },
+            },
+        },
+    )
+    _write_ndjson(
+        run_dir / "events.ndjson",
+        [
+            {"event_type": "reconciliation", "cycle_id": "cycle-0001"},
+            {"event_type": "order_preview", "cycle_id": "cycle-0001"},
+            {
+                "event_type": "order_fill",
+                "cycle_id": "cycle-0001",
+                "fills": [
+                    {"size": 0.1, "price": 100.0},
+                    {"size": 0.05, "price": 110.0},
+                ],
+                "execution_summary": {"reason_code": "filled"},
+            }
+        ],
+    )
+
+    analysis = analyze_run(run_dir)
+
+    assert analysis.mode == "live"
+    assert analysis.cycle_count == 1
+    assert analysis.starting_equity_usdc == 10000.0
+    assert analysis.ending_equity_usdc == 10125.0
+    assert analysis.total_pnl_usdc == 125.0
+    assert analysis.total_return_pct == 0.0125
+    assert analysis.unrealized_pnl_usdc == 25.0
+    assert analysis.fill_count == 2
+    assert analysis.turnover_usdc == 15.5
+    assert analysis.avg_abs_exposure_pct == 0.2
+    assert analysis.decision_counts == {"filled": 1}


### PR DESCRIPTION
## Summary
- add a reusable Python analyzer for run artifacts that computes canonical pnl, drawdown, turnover, exposure, and decision metrics
- support both paper artifact series and live-state fallbacks so the contract can cover any readable run
- add unit coverage for paper and live-fallback analysis paths

## Testing
- python3 -m pytest
- python3 -m ruff check src/perpfut/analysis.py tests/unit/test_analysis.py

Closes #35