### PR TITLE
Add analysis CLI and API surfaces

### DIFF
--- a/apps/web/lib/perpfut-api.ts
+++ b/apps/web/lib/perpfut-api.ts
@@ -36,9 +36,42 @@ export type DashboardOverviewResponse = {
   latest_run: RunSummary | null;
   latest_state: Record<string, unknown> | null;
   latest_decision: LatestDecision | null;
+  latest_analysis: RunAnalysis | null;
   recent_events: Record<string, unknown>[];
   recent_fills: Record<string, unknown>[];
   recent_positions: Record<string, unknown>[];
+};
+
+export type AnalysisSeriesPoint = {
+  label: string;
+  value: number;
+};
+
+export type RunAnalysis = {
+  run_id: string;
+  mode: string | null;
+  product_id: string | null;
+  strategy_id: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+  cycle_count: number;
+  starting_equity_usdc: number;
+  ending_equity_usdc: number;
+  realized_pnl_usdc: number;
+  unrealized_pnl_usdc: number;
+  total_pnl_usdc: number;
+  total_return_pct: number;
+  max_drawdown_usdc: number;
+  max_drawdown_pct: number;
+  turnover_usdc: number;
+  fill_count: number;
+  trade_count: number;
+  avg_abs_exposure_pct: number;
+  max_abs_exposure_pct: number;
+  decision_counts: Record<string, number>;
+  equity_series: AnalysisSeriesPoint[];
+  drawdown_series: AnalysisSeriesPoint[];
+  exposure_series: AnalysisSeriesPoint[];
 };
 
 export type SignalDecision = {
@@ -94,6 +127,8 @@ export type ArtifactListResponse = {
   items: Record<string, unknown>[];
   count: number;
 };
+
+export type RunAnalysisResponse = RunAnalysis;
 
 const API_BASE = "/api/perpfut";
 

--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -33,6 +33,7 @@ All routes are rooted at `/api`.
 - `GET /api/runs/{runId}/events?limit=`
 - `GET /api/runs/{runId}/fills?limit=`
 - `GET /api/runs/{runId}/positions?limit=`
+- `GET /api/runs/{runId}/analysis`
 - `GET /api/paper-runs/active`
 
 ### Control routes
@@ -60,6 +61,7 @@ The service allows only one active paper run at a time.
 - `latest_run`: newest readable run matching the requested mode
 - `latest_state`: raw latest checkpoint payload for the run
 - `latest_decision`: normalized operator-facing decision summary derived from the latest checkpoint
+- `latest_analysis`: canonical performance summary derived from the run artifacts
 - `recent_events`, `recent_fills`, `recent_positions`: newest-first artifact rows
 
 `latest_decision` contains:
@@ -75,6 +77,16 @@ The service allows only one active paper run at a time.
 - `fill`
 
 The nested decision objects use the same field names written into run artifacts.
+
+`GET /api/runs/{runId}/analysis` returns the same canonical analysis payload used by
+`latest_analysis`, including:
+
+- run identity: `run_id`, `mode`, `product_id`, `strategy_id`
+- timing: `started_at`, `ended_at`, `cycle_count`
+- pnl and return: `starting_equity_usdc`, `ending_equity_usdc`, `realized_pnl_usdc`, `unrealized_pnl_usdc`, `total_pnl_usdc`, `total_return_pct`
+- risk and activity: `max_drawdown_usdc`, `max_drawdown_pct`, `turnover_usdc`, `fill_count`, `trade_count`
+- exposure and decisions: `avg_abs_exposure_pct`, `max_abs_exposure_pct`, `decision_counts`
+- chart series: `equity_series`, `drawdown_series`, `exposure_series`
 
 ## Design Notes
 

--- a/src/perpfut/analysis.py
+++ b/src/perpfut/analysis.py
@@ -45,8 +45,8 @@ class RunAnalysis:
 
 
 def analyze_run(run_dir: Path) -> RunAnalysis:
-    manifest = load_run_manifest(run_dir)
-    state = load_run_state(run_dir)
+    manifest = _require_dict(load_run_manifest(run_dir), run_dir / "manifest.json")
+    state = _require_dict(load_run_state(run_dir), run_dir / "state.json")
     config = _load_optional_json(run_dir / "config.json") or {}
     events = _load_optional_ndjson(run_dir / "events.ndjson")
     positions = _load_optional_ndjson(run_dir / "positions.ndjson")
@@ -110,17 +110,21 @@ def analyze_run(run_dir: Path) -> RunAnalysis:
 def _load_optional_json(path: Path) -> dict[str, Any] | None:
     if not path.exists():
         return None
-    return json.loads(path.read_text(encoding="utf-8"))
+    return _require_dict(json.loads(path.read_text(encoding="utf-8")), path)
 
 
 def _load_optional_ndjson(path: Path) -> list[dict[str, Any]]:
     if not path.exists():
         return []
-    return [
-        json.loads(line)
-        for line in path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        if not isinstance(payload, dict):
+            raise ValueError(f"invalid ndjson row in {path}")
+        rows.append(payload)
+    return rows
 
 
 def _resolve_max_abs_notional(config: dict[str, Any]) -> float:
@@ -359,3 +363,9 @@ def _as_float(value: Any) -> float | None:
 
 def _as_str(value: Any) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _require_dict(value: Any, path: Path) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid json object in {path}")
+    return value

--- a/src/perpfut/api/repository.py
+++ b/src/perpfut/api/repository.py
@@ -7,12 +7,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..analysis import RunAnalysis, analyze_run
 from .schemas import (
+    AnalysisSeriesPointResponse,
     DashboardOverviewResponse,
     ExecutionSummaryResponse,
     LatestDecisionResponse,
     NoTradeReasonResponse,
     RiskDecisionResponse,
+    RunAnalysisResponse,
     RunSummaryResponse,
     RunsListResponse,
     SignalDecisionResponse,
@@ -38,6 +41,7 @@ def build_dashboard_overview(*, mode: str, limit: int = 10) -> DashboardOverview
     items = _collect_run_summaries(get_runs_dir(), mode=mode, limit=1)
     latest_run = items[0] if items else None
     latest_state = None
+    latest_analysis = None
     recent_events: list[dict[str, Any]] = []
     recent_fills: list[dict[str, Any]] = []
     recent_positions: list[dict[str, Any]] = []
@@ -45,6 +49,7 @@ def build_dashboard_overview(*, mode: str, limit: int = 10) -> DashboardOverview
     if latest_run is not None:
         run_dir = get_runs_dir() / latest_run.run_id
         latest_state = load_artifact_document(run_dir.name, "state.json", required=False)
+        latest_analysis = load_run_analysis(run_dir.name, required=False)
         recent_events = load_artifact_list(run_dir.name, "events.ndjson", limit=limit, required=False)
         recent_fills = load_artifact_list(run_dir.name, "fills.ndjson", limit=limit, required=False)
         recent_positions = load_artifact_list(run_dir.name, "positions.ndjson", limit=limit, required=False)
@@ -55,10 +60,25 @@ def build_dashboard_overview(*, mode: str, limit: int = 10) -> DashboardOverview
         latest_run=latest_run,
         latest_state=latest_state,
         latest_decision=_build_latest_decision(latest_state),
+        latest_analysis=latest_analysis,
         recent_events=recent_events,
         recent_fills=recent_fills,
         recent_positions=recent_positions,
     )
+
+
+def load_run_analysis(run_id: str, *, required: bool = True) -> RunAnalysisResponse | None:
+    run_dir = _resolve_run_dir(run_id)
+    try:
+        return _build_run_analysis_response(analyze_run(run_dir))
+    except FileNotFoundError as exc:
+        if required:
+            raise exc
+        return None
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        if required:
+            raise ArtifactError(f"invalid analysis inputs: {run_dir}") from exc
+        return None
 
 
 def load_artifact_document(run_id: str, filename: str, *, required: bool = True) -> dict[str, Any] | None:
@@ -70,12 +90,14 @@ def load_artifact_document(run_id: str, filename: str, *, required: bool = True)
         return None
     try:
         if filename == "state.json":
-            return load_run_state(run_dir)
+            return _require_document_dict(load_run_state(run_dir), path)
         if filename == "manifest.json":
-            return load_run_manifest(run_dir)
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ArtifactError(f"invalid artifact: {path}") from exc
+            return _require_document_dict(load_run_manifest(run_dir), path)
+        return _require_document_dict(json.loads(path.read_text(encoding="utf-8")), path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        if required:
+            raise ArtifactError(f"invalid artifact: {path}") from exc
+        return None
 
 
 def load_artifact_list(
@@ -92,13 +114,18 @@ def load_artifact_list(
             raise FileNotFoundError(path)
         return []
     try:
-        lines = [
-            json.loads(line)
-            for line in path.read_text(encoding="utf-8").splitlines()
-            if line.strip()
-        ]
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ArtifactError(f"invalid artifact: {path}") from exc
+        lines: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"invalid ndjson row in {path}")
+            lines.append(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        if required:
+            raise ArtifactError(f"invalid artifact: {path}") from exc
+        return []
     return list(reversed(lines))[:limit]
 
 
@@ -109,8 +136,8 @@ def _collect_run_summaries(base_dir: Path, *, mode: str | None, limit: int) -> l
         if not manifest_path.exists():
             continue
         try:
-            manifest = load_run_manifest(run_dir)
-        except (OSError, json.JSONDecodeError):
+            manifest = _require_document_dict(load_run_manifest(run_dir), manifest_path)
+        except (OSError, json.JSONDecodeError, ValueError):
             continue
         if mode is not None and manifest.get("mode") != mode:
             continue
@@ -163,9 +190,48 @@ def _build_latest_decision(latest_state: dict[str, Any] | None) -> LatestDecisio
     )
 
 
+def _build_run_analysis_response(analysis: RunAnalysis) -> RunAnalysisResponse:
+    return RunAnalysisResponse(
+        run_id=analysis.run_id,
+        mode=analysis.mode,
+        product_id=analysis.product_id,
+        strategy_id=analysis.strategy_id,
+        started_at=analysis.started_at,
+        ended_at=analysis.ended_at,
+        cycle_count=analysis.cycle_count,
+        starting_equity_usdc=analysis.starting_equity_usdc,
+        ending_equity_usdc=analysis.ending_equity_usdc,
+        realized_pnl_usdc=analysis.realized_pnl_usdc,
+        unrealized_pnl_usdc=analysis.unrealized_pnl_usdc,
+        total_pnl_usdc=analysis.total_pnl_usdc,
+        total_return_pct=analysis.total_return_pct,
+        max_drawdown_usdc=analysis.max_drawdown_usdc,
+        max_drawdown_pct=analysis.max_drawdown_pct,
+        turnover_usdc=analysis.turnover_usdc,
+        fill_count=analysis.fill_count,
+        trade_count=analysis.trade_count,
+        avg_abs_exposure_pct=analysis.avg_abs_exposure_pct,
+        max_abs_exposure_pct=analysis.max_abs_exposure_pct,
+        decision_counts=analysis.decision_counts,
+        equity_series=_build_series_points(analysis.equity_series),
+        drawdown_series=_build_series_points(analysis.drawdown_series),
+        exposure_series=_build_series_points(analysis.exposure_series),
+    )
+
+
+def _build_series_points(points: tuple[Any, ...]) -> list[AnalysisSeriesPointResponse]:
+    return [AnalysisSeriesPointResponse(label=point.label, value=point.value) for point in points]
+
+
 def _coerce_dict(value: Any) -> dict[str, Any] | None:
     return value if isinstance(value, dict) else None
 
 
 def _coerce_str(value: Any) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _require_document_dict(value: Any, path: Path) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid json object in {path}")
+    return value

--- a/src/perpfut/api/routers/runs.py
+++ b/src/perpfut/api/routers/runs.py
@@ -6,8 +6,14 @@ from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query
 
-from ..repository import ArtifactError, list_run_summaries, load_artifact_document, load_artifact_list
-from ..schemas import ArtifactDocumentResponse, ArtifactListResponse, RunsListResponse
+from ..repository import (
+    ArtifactError,
+    list_run_summaries,
+    load_artifact_document,
+    load_artifact_list,
+    load_run_analysis,
+)
+from ..schemas import ArtifactDocumentResponse, ArtifactListResponse, RunAnalysisResponse, RunsListResponse
 
 
 router = APIRouter(tags=["runs"])
@@ -53,6 +59,18 @@ def read_run_positions(
     limit: int = Query(default=50, ge=1, le=500),
 ) -> ArtifactListResponse:
     return _build_list_response(run_id, "positions.ndjson", limit=limit)
+
+
+@router.get("/runs/{run_id}/analysis", response_model=RunAnalysisResponse)
+def read_run_analysis(run_id: str) -> RunAnalysisResponse:
+    try:
+        analysis = load_run_analysis(run_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="analysis inputs not found") from exc
+    except ArtifactError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    assert analysis is not None
+    return analysis
 
 
 def _load_document(run_id: str, filename: str) -> dict:

--- a/src/perpfut/api/schemas.py
+++ b/src/perpfut/api/schemas.py
@@ -82,12 +82,45 @@ class LatestDecisionResponse(BaseModel):
     fill: dict[str, Any] | None = None
 
 
+class AnalysisSeriesPointResponse(BaseModel):
+    label: str
+    value: float
+
+
+class RunAnalysisResponse(BaseModel):
+    run_id: str
+    mode: str | None = None
+    product_id: str | None = None
+    strategy_id: str | None = None
+    started_at: str | None = None
+    ended_at: str | None = None
+    cycle_count: int
+    starting_equity_usdc: float
+    ending_equity_usdc: float
+    realized_pnl_usdc: float
+    unrealized_pnl_usdc: float
+    total_pnl_usdc: float
+    total_return_pct: float
+    max_drawdown_usdc: float
+    max_drawdown_pct: float
+    turnover_usdc: float
+    fill_count: int
+    trade_count: int
+    avg_abs_exposure_pct: float
+    max_abs_exposure_pct: float
+    decision_counts: dict[str, int]
+    equity_series: list[AnalysisSeriesPointResponse]
+    drawdown_series: list[AnalysisSeriesPointResponse]
+    exposure_series: list[AnalysisSeriesPointResponse]
+
+
 class DashboardOverviewResponse(BaseModel):
     mode: str
     generated_at: datetime
     latest_run: RunSummaryResponse | None = None
     latest_state: dict[str, Any] | None = None
     latest_decision: LatestDecisionResponse | None = None
+    latest_analysis: RunAnalysisResponse | None = None
     recent_events: list[dict[str, Any]] = Field(default_factory=list)
     recent_fills: list[dict[str, Any]] = Field(default_factory=list)
     recent_positions: list[dict[str, Any]] = Field(default_factory=list)

--- a/src/perpfut/cli.py
+++ b/src/perpfut/cli.py
@@ -8,6 +8,7 @@ import os
 from dataclasses import asdict
 from pathlib import Path
 
+from .analysis import analyze_run
 from .api.server import run_api_server
 from .config import AppConfig
 from .domain import Mode
@@ -41,6 +42,12 @@ def build_parser() -> argparse.ArgumentParser:
     state_parser.add_argument("--runs-dir", type=Path, default=None)
     state_parser.add_argument("--mode", choices=["paper", "live"], default="live")
     state_parser.add_argument("--product-id", default=None)
+
+    analyze_parser = subparsers.add_parser("analyze", help="analyze a run's performance artifacts")
+    analyze_parser.add_argument("--run-id", default=None)
+    analyze_parser.add_argument("--runs-dir", type=Path, default=None)
+    analyze_parser.add_argument("--mode", choices=["paper", "live"], default="paper")
+    analyze_parser.add_argument("--product-id", default=None)
 
     reconcile_parser = subparsers.add_parser(
         "reconcile",
@@ -84,6 +91,8 @@ def main(argv: list[str] | None = None) -> int:
         return _list_runs(args)
     if args.command == "state":
         return _show_state(args)
+    if args.command == "analyze":
+        return _run_analyze(args)
     if args.command == "reconcile":
         return _run_reconcile(args)
     if args.command == "preflight":
@@ -145,6 +154,31 @@ def _show_state(args: argparse.Namespace) -> int:
         if run_dir is None:
             raise SystemExit("no runs found")
     print(json.dumps(load_run_state(run_dir), indent=2, sort_keys=True))
+    return 0
+
+
+def _run_analyze(args: argparse.Namespace) -> int:
+    config = AppConfig.from_env().with_overrides(runs_dir=args.runs_dir)
+    if args.run_id:
+        run_dir = config.runtime.runs_dir / args.run_id
+        if not run_dir.exists():
+            raise SystemExit(f"run not found: {args.run_id}")
+    else:
+        run_dir = find_latest_run(
+            config.runtime.runs_dir,
+            mode=args.mode,
+            product_id=args.product_id,
+            require_state=True,
+        )
+        if run_dir is None:
+            raise SystemExit("no runs found")
+    try:
+        analysis = analyze_run(run_dir)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"analysis inputs not found for run: {run_dir.name}") from exc
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        raise SystemExit(f"invalid analysis inputs for run: {run_dir.name}") from exc
+    print(json.dumps(asdict(analysis), indent=2, sort_keys=True))
     return 0
 
 

--- a/tests/integration/test_api_runs.py
+++ b/tests/integration/test_api_runs.py
@@ -77,25 +77,67 @@ def _make_run(
                 },
             },
         )
+    _write_json(
+        run_dir / "config.json",
+        {
+            "simulation": {
+                "starting_collateral_usdc": 10_000.0,
+                "max_leverage": 2.0,
+            },
+            "strategy": {
+                "strategy_id": "momentum",
+            },
+        },
+    )
     _write_ndjson(
         run_dir / "events.ndjson",
         [
-            {"event_type": "cycle", "sequence": 1},
-            {"event_type": "cycle", "sequence": 2},
+            {
+                "cycle_id": "cycle-0001",
+                "event_type": "cycle",
+                "sequence": 1,
+                "timestamp": "2026-03-21T01:00:00Z",
+                "execution_summary": {"reason_code": "below_rebalance_threshold"},
+            },
+            {
+                "cycle_id": "cycle-0002",
+                "event_type": "cycle",
+                "sequence": 2,
+                "timestamp": "2026-03-21T01:01:00Z",
+                "execution_summary": {"reason_code": "filled"},
+            },
         ],
     )
     _write_ndjson(
         run_dir / "fills.ndjson",
         [
-            {"fill_id": "fill-1", "price": 100.0},
-            {"fill_id": "fill-2", "price": 101.0},
+            {"fill_id": "fill-1", "price": 100.0, "quantity": 0.5},
+            {"fill_id": "fill-2", "price": 101.0, "quantity": 0.75},
         ],
     )
     _write_ndjson(
         run_dir / "positions.ndjson",
         [
-            {"position": {"quantity": 0.1}},
-            {"position": {"quantity": 0.2}},
+            {
+                "cycle_id": "cycle-0001",
+                "position": {
+                    "quantity": 0.1,
+                    "collateral_usdc": 10_000.0,
+                    "realized_pnl_usdc": 0.0,
+                    "entry_price": 100.0,
+                    "mark_price": 100.0,
+                },
+            },
+            {
+                "cycle_id": "cycle-0002",
+                "position": {
+                    "quantity": 0.2,
+                    "collateral_usdc": 10_000.0,
+                    "realized_pnl_usdc": 25.0,
+                    "entry_price": 100.0,
+                    "mark_price": 101.0,
+                },
+            },
         ],
     )
 
@@ -130,6 +172,12 @@ def test_dashboard_overview_uses_latest_matching_run_and_newest_first_lists(monk
     assert payload["latest_decision"]["cycle_id"] == "cycle-0002"
     assert payload["latest_decision"]["execution_summary"]["reason_code"] == "filled"
     assert payload["latest_decision"]["risk_decision"]["rebalance_eligible"] is True
+    assert payload["latest_analysis"]["run_id"] == "20260322T020000000000Z_beta"
+    assert payload["latest_analysis"]["strategy_id"] == "momentum"
+    assert payload["latest_analysis"]["decision_counts"] == {
+        "below_rebalance_threshold": 1,
+        "filled": 1,
+    }
     assert payload["recent_events"][0]["sequence"] == 2
     assert payload["recent_fills"][0]["fill_id"] == "fill-2"
     assert payload["recent_positions"][0]["position"]["quantity"] == 0.2
@@ -168,6 +216,78 @@ def test_run_artifact_endpoints_wrap_documents_and_lists(monkeypatch, tmp_path) 
     assert events_response.json()["items"][0]["sequence"] == 2
 
 
+def test_run_analysis_endpoint_returns_canonical_metrics(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper")
+    client = TestClient(create_app())
+
+    response = client.get(f"/api/runs/{run_id}/analysis")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["run_id"] == run_id
+    assert payload["mode"] == "paper"
+    assert payload["product_id"] == "BTC-PERP-INTX"
+    assert payload["strategy_id"] == "momentum"
+    assert payload["fill_count"] == 2
+    assert payload["trade_count"] == 2
+    assert payload["turnover_usdc"] == 125.75
+    assert payload["cycle_count"] == 2
+    assert payload["equity_series"][-1]["value"] == 10025.2
+
+
+def test_run_analysis_returns_not_found_when_state_missing(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper", include_state=False)
+    client = TestClient(create_app())
+
+    response = client.get(f"/api/runs/{run_id}/analysis")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "analysis inputs not found"
+
+
+def test_run_analysis_returns_server_error_for_shape_invalid_ndjson(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper")
+    (tmp_path / run_id / "events.ndjson").write_text("[]\n", encoding="utf-8")
+    client = TestClient(create_app())
+
+    response = client.get(f"/api/runs/{run_id}/analysis")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == f"invalid analysis inputs: {tmp_path / run_id}"
+
+
+def test_dashboard_overview_downgrades_invalid_analysis_to_null(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper")
+    (tmp_path / run_id / "events.ndjson").write_text("[]\n", encoding="utf-8")
+    client = TestClient(create_app())
+
+    response = client.get("/api/dashboard/overview", params={"mode": "paper", "limit": 1})
+
+    assert response.status_code == 200
+    assert response.json()["latest_analysis"] is None
+
+
+def test_run_analysis_returns_server_error_for_shape_invalid_state_json(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper")
+    (tmp_path / run_id / "state.json").write_text("[1]\n", encoding="utf-8")
+    client = TestClient(create_app())
+
+    response = client.get(f"/api/runs/{run_id}/analysis")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == f"invalid analysis inputs: {tmp_path / run_id}"
+
+
 def test_dashboard_overview_allows_latest_decision_to_be_null_for_older_runs(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("RUNS_DIR", str(tmp_path))
     run_id = "20260322T020000000000Z_legacy"
@@ -187,6 +307,22 @@ def test_dashboard_overview_allows_latest_decision_to_be_null_for_older_runs(mon
     assert response.json()["latest_decision"] is None
 
 
+def test_dashboard_overview_downgrades_shape_invalid_state_document(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, run_id, mode="paper")
+    (tmp_path / run_id / "state.json").write_text("[1]\n", encoding="utf-8")
+    client = TestClient(create_app())
+
+    response = client.get("/api/dashboard/overview", params={"mode": "paper", "limit": 1})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["latest_state"] is None
+    assert payload["latest_decision"] is None
+    assert payload["latest_analysis"] is None
+
+
 def test_missing_state_returns_not_found(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("RUNS_DIR", str(tmp_path))
     run_id = "20260322T020000000000Z_beta"
@@ -197,3 +333,21 @@ def test_missing_state_returns_not_found(monkeypatch, tmp_path) -> None:
 
     assert response.status_code == 404
     assert "state.json" in response.json()["detail"]
+
+
+def test_runs_and_dashboard_skip_shape_invalid_manifest(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("RUNS_DIR", str(tmp_path))
+    invalid_run_id = "20260322T030000000000Z_invalid"
+    valid_run_id = "20260322T020000000000Z_beta"
+    _make_run(tmp_path, invalid_run_id, mode="paper")
+    _make_run(tmp_path, valid_run_id, mode="paper")
+    (tmp_path / invalid_run_id / "manifest.json").write_text("[1]\n", encoding="utf-8")
+    client = TestClient(create_app())
+
+    runs_response = client.get("/api/runs", params={"mode": "paper", "limit": 2})
+    overview_response = client.get("/api/dashboard/overview", params={"mode": "paper", "limit": 1})
+
+    assert runs_response.status_code == 200
+    assert runs_response.json()["items"][0]["run_id"] == valid_run_id
+    assert overview_response.status_code == 200
+    assert overview_response.json()["latest_run"]["run_id"] == valid_run_id

--- a/tests/unit/test_api_cli.py
+++ b/tests/unit/test_api_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from perpfut.cli import build_parser, main
 
 
@@ -24,3 +26,197 @@ def test_api_main_invokes_server(monkeypatch) -> None:
 
     assert exit_code == 0
     assert captured == {"host": "127.0.0.1", "port": 9000}
+
+
+def test_analyze_parser_defaults() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["analyze"])
+
+    assert args.command == "analyze"
+    assert args.run_id is None
+    assert args.mode == "paper"
+
+
+def test_analyze_main_prints_run_analysis(monkeypatch, tmp_path, capsys) -> None:
+    run_id = "20260322T020000000000Z_beta"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "created_at": "2026-03-21T01:00:00Z",
+                "mode": "paper",
+                "product_id": "BTC-PERP-INTX",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "simulation": {
+                    "starting_collateral_usdc": 10_000.0,
+                    "max_leverage": 2.0,
+                },
+                "strategy": {
+                    "strategy_id": "momentum",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "cycle_id": "cycle-0001",
+                "mode": "paper",
+                "position": {
+                    "collateral_usdc": 10_000.0,
+                    "realized_pnl_usdc": 20.0,
+                    "quantity": 0.25,
+                    "entry_price": 100.0,
+                    "mark_price": 102.0,
+                },
+                "execution_summary": {
+                    "reason_code": "filled",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "events.ndjson").write_text(
+        json.dumps(
+            {
+                "cycle_id": "cycle-0001",
+                "timestamp": "2026-03-21T01:00:00Z",
+                "execution_summary": {
+                    "reason_code": "filled",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "fills.ndjson").write_text(
+        json.dumps({"fill_id": "fill-1", "price": 102.0, "quantity": 0.25}) + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "positions.ndjson").write_text(
+        json.dumps(
+            {
+                "cycle_id": "cycle-0001",
+                "position": {
+                    "collateral_usdc": 10_000.0,
+                    "realized_pnl_usdc": 20.0,
+                    "quantity": 0.25,
+                    "entry_price": 100.0,
+                    "mark_price": 102.0,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["analyze", "--runs-dir", str(tmp_path), "--run-id", run_id])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run_id"] == run_id
+    assert payload["strategy_id"] == "momentum"
+    assert payload["fill_count"] == 1
+    assert payload["decision_counts"] == {"filled": 1}
+
+
+def test_analyze_main_exits_cleanly_when_state_is_missing(tmp_path) -> None:
+    run_id = "20260322T020000000000Z_beta"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "created_at": "2026-03-21T01:00:00Z",
+                "mode": "paper",
+                "product_id": "BTC-PERP-INTX",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        main(["analyze", "--runs-dir", str(tmp_path), "--run-id", run_id])
+    except SystemExit as exc:
+        assert str(exc) == f"analysis inputs not found for run: {run_id}"
+    else:
+        raise AssertionError("expected SystemExit")
+
+
+def test_analyze_main_exits_cleanly_when_ndjson_shape_is_invalid(tmp_path) -> None:
+    run_id = "20260322T020000000000Z_beta"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "created_at": "2026-03-21T01:00:00Z",
+                "mode": "paper",
+                "product_id": "BTC-PERP-INTX",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "state.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "cycle_id": "cycle-0001",
+                "mode": "paper",
+                "position": {
+                    "collateral_usdc": 10_000.0,
+                    "realized_pnl_usdc": 0.0,
+                    "quantity": 0.0,
+                    "entry_price": 100.0,
+                    "mark_price": 100.0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "events.ndjson").write_text("[]\n", encoding="utf-8")
+
+    try:
+        main(["analyze", "--runs-dir", str(tmp_path), "--run-id", run_id])
+    except SystemExit as exc:
+        assert str(exc) == f"invalid analysis inputs for run: {run_id}"
+    else:
+        raise AssertionError("expected SystemExit")
+
+
+def test_analyze_main_exits_cleanly_when_state_json_shape_is_invalid(tmp_path) -> None:
+    run_id = "20260322T020000000000Z_beta"
+    run_dir = tmp_path / run_id
+    run_dir.mkdir(parents=True)
+    (run_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "created_at": "2026-03-21T01:00:00Z",
+                "mode": "paper",
+                "product_id": "BTC-PERP-INTX",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "state.json").write_text("[1]\n", encoding="utf-8")
+
+    try:
+        main(["analyze", "--runs-dir", str(tmp_path), "--run-id", run_id])
+    except SystemExit as exc:
+        assert str(exc) == f"invalid analysis inputs for run: {run_id}"
+    else:
+        raise AssertionError("expected SystemExit")


### PR DESCRIPTION
Closes #36

## Summary
- add canonical run analysis to the operator API and dashboard overview
- add a `perpfut analyze` CLI command for direct artifact inspection
- cover the new surfaces with API and CLI tests

## Testing
- python3 -m pytest
- python3 -m ruff check src/perpfut/api src/perpfut/cli.py tests/unit/test_api_cli.py tests/integration/test_api_runs.py