### PR TITLE
Render reporting from canonical analysis

### DIFF
--- a/apps/web/components/operator-shell.test.tsx
+++ b/apps/web/components/operator-shell.test.tsx
@@ -50,6 +50,44 @@ const overviewResponse = {
   latest_state: {
     equity_usdc: 10125,
   },
+  latest_analysis: {
+    run_id: "20260322T020000000000Z_demo",
+    mode: "paper",
+    product_id: "BTC-PERP-INTX",
+    strategy_id: "momentum",
+    started_at: "2026-03-22T02:00:00Z",
+    ended_at: "2026-03-22T02:10:00Z",
+    cycle_count: 12,
+    starting_equity_usdc: 10000,
+    ending_equity_usdc: 10125,
+    realized_pnl_usdc: 80,
+    unrealized_pnl_usdc: 45,
+    total_pnl_usdc: 125,
+    total_return_pct: 0.0125,
+    max_drawdown_usdc: 40,
+    max_drawdown_pct: 0.004,
+    turnover_usdc: 5200,
+    fill_count: 3,
+    trade_count: 3,
+    avg_abs_exposure_pct: 0.22,
+    max_abs_exposure_pct: 0.35,
+    decision_counts: {
+      filled: 3,
+      below_rebalance_threshold: 9,
+    },
+    equity_series: [
+      { label: "cycle-1", value: 10000 },
+      { label: "cycle-12", value: 10125 },
+    ],
+    drawdown_series: [
+      { label: "cycle-1", value: 0 },
+      { label: "cycle-12", value: 40 },
+    ],
+    exposure_series: [
+      { label: "cycle-1", value: 0.1 },
+      { label: "cycle-12", value: 0.22 },
+    ],
+  },
   latest_decision: {
     cycle_id: "cycle-2",
     mode: "paper",
@@ -187,7 +225,9 @@ describe("OperatorShell", () => {
     renderShell();
 
     expect(await screen.findByText("Start or stop the local paper process")).toBeInTheDocument();
-    expect(await screen.findByText("$10,125")).toBeInTheDocument();
+    expect(await screen.findByText("+1.25%")).toBeInTheDocument();
+    expect(screen.queryByText("Canonical analysis unavailable")).not.toBeInTheDocument();
+    expect(screen.getByText("Equity Curve")).toBeInTheDocument();
     expect(screen.getByText("Latest Cycle Decision")).toBeInTheDocument();
     expect(screen.getByText("Filled a rebalance order toward the target position.")).toBeInTheDocument();
 
@@ -317,6 +357,39 @@ describe("OperatorShell", () => {
     expect(
       screen.getByText("The latest readable run has not produced a normalized decision summary yet.")
     ).toBeInTheDocument();
+  });
+
+  it("renders the performance fallback when canonical analysis is not available yet", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path.startsWith("/dashboard/overview")) {
+        return {
+          ...overviewResponse,
+          latest_analysis: null,
+        };
+      }
+      if (path.startsWith("/runs?")) {
+        return runsResponse;
+      }
+      if (path === "/paper-runs/active") {
+        return {
+          active: false,
+          pid: null,
+          started_at: null,
+          run_id: null,
+          product_id: null,
+          iterations: null,
+          interval_seconds: null,
+          starting_collateral_usdc: null,
+          log_path: null,
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderShell();
+
+    expect(await screen.findByText("Canonical analysis unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Total Return")).not.toBeInTheDocument();
   });
 
   it("renders a halted decision summary from structured reason fields", async () => {

--- a/apps/web/components/operator-shell.tsx
+++ b/apps/web/components/operator-shell.tsx
@@ -15,8 +15,11 @@ import {
 
 import {
   buildDashboardMetrics,
+  formatCount,
   formatMoney,
+  formatPercent,
   formatSigned,
+  formatSignedPercent,
   formatTimestamp,
 } from "@/lib/dashboard-metrics";
 import {
@@ -269,6 +272,18 @@ function LatestDecisionPanel({ decision }: { decision: LatestDecision | null }) 
   );
 }
 
+function PerformanceUnavailablePanel() {
+  return (
+    <Panel className="p-5">
+      <SectionHeader eyebrow="Performance" title="Canonical analysis unavailable" />
+      <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+        This run does not yet have a readable canonical analysis payload. Performance cards and
+        charts will populate once the latest run exposes a readable analysis artifact.
+      </div>
+    </Panel>
+  );
+}
+
 function ControlBanner({ feedback }: { feedback: ControlFeedback }) {
   const classes =
     feedback.tone === "success"
@@ -488,6 +503,10 @@ function parsePaperRunRequest(form: typeof DEFAULT_PAPER_FORM): {
   };
 }
 
+function formatTooltipPercent(value: unknown): string {
+  return typeof value === "number" ? `${(value * 100).toFixed(2)}%` : "--";
+}
+
 function formatControlError(error: unknown): ControlFeedback {
   if (error instanceof ApiError) {
     if (error.status === 409) {
@@ -530,6 +549,7 @@ export function OperatorShell() {
 
   const overviewData = overview.data;
   const metrics = overviewData ? buildDashboardMetrics(overviewData) : null;
+  const latestAnalysis = overviewData?.latest_analysis ?? null;
   const latestRun = overviewData?.latest_run;
   const currentProductId = latestRun?.product_id ?? activeRun.data?.product_id ?? form.productId;
   const isLoading = overview.isLoading || runs.isLoading || activeRun.isLoading;
@@ -714,120 +734,171 @@ export function OperatorShell() {
 
           {!error && !isLoading && latestRun && metrics && overviewData ? (
             <>
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-                <StatCard
-                  label="Equity"
-                  value={formatMoney(metrics.equityUsd)}
-                  change={`${metrics.equitySeries.length} cycle points`}
-                  tone="accent"
-                />
-                <StatCard
-                  label="Realized PnL"
-                  value={formatMoney(metrics.realizedPnlUsd)}
-                  change={`${formatSigned(metrics.unrealizedPnlUsd)} unrealized`}
-                  tone="accent"
-                />
-                <StatCard
-                  label="Net Position"
-                  value={metrics.quantity === null ? "--" : `${metrics.quantity.toFixed(4)} base`}
-                  change={`target ${formatSigned(metrics.targetPosition, 3)}`}
-                />
-                <StatCard
-                  label="Signal"
-                  value={formatSigned(metrics.lastSignalRaw, 4)}
-                  change={`${metrics.fillCount} fills / ${metrics.eventCount} events`}
-                  tone="warning"
-                />
-              </div>
-
               <LatestDecisionPanel decision={overviewData.latest_decision} />
 
-              <div className="grid gap-4 xl:grid-cols-[1.45fr_1fr]">
-                <Panel className="p-5">
-                  <SectionHeader
-                    eyebrow="Signal"
-                    title="Equity And Realized PnL"
-                    action={`${metrics.equitySeries.length} plotted cycles`}
-                  />
-                  <div className="signal-grid h-80 border border-[var(--border)] p-3">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={metrics.equitySeries}>
-                        <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
-                        <XAxis
-                          dataKey="label"
-                          tick={{ fill: "#90a4bf", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={false}
-                        />
-                        <YAxis
-                          tick={{ fill: "#90a4bf", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={false}
-                          width={80}
-                        />
-                        <Tooltip
-                          contentStyle={{
-                            border: "1px solid rgba(135, 162, 196, 0.22)",
-                            background: "rgba(8, 12, 20, 0.96)",
-                            color: "#ecf4ff",
-                          }}
-                        />
-                        <Line type="monotone" dataKey="equity" stroke="#8fd6ff" strokeWidth={2.5} dot={false} />
-                        <Line
-                          type="monotone"
-                          dataKey="realizedPnl"
-                          stroke="#f1bb67"
-                          strokeWidth={2}
-                          dot={false}
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
+              {latestAnalysis ? (
+                <div className="space-y-4">
+                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                    <StatCard
+                      label="Total Return"
+                      value={formatSignedPercent(metrics.totalReturnPct)}
+                      change={`${formatMoney(metrics.totalPnlUsd)} total PnL across ${formatCount(metrics.cycleCount)} cycles`}
+                      tone="accent"
+                    />
+                    <StatCard
+                      label="P&L Stack"
+                      value={formatMoney(metrics.totalPnlUsd)}
+                      change={`${formatMoney(metrics.realizedPnlUsd)} realized / ${formatMoney(metrics.unrealizedPnlUsd)} unrealized`}
+                      tone="accent"
+                    />
+                    <StatCard
+                      label="Max Drawdown"
+                      value={formatPercent(metrics.maxDrawdownPct)}
+                      change={`${formatMoney(metrics.maxDrawdownUsd)} worst peak-to-trough`}
+                    />
+                    <StatCard
+                      label="Turnover / Exposure"
+                      value={`${formatCount(metrics.tradeCount ?? metrics.fillCount)} trades`}
+                      change={`${formatMoney(metrics.turnoverUsd)} turnover / ${formatPercent(metrics.avgAbsExposurePct)} avg exposure`}
+                      tone="warning"
+                    />
                   </div>
-                </Panel>
 
-                <Panel className="p-5">
-                  <SectionHeader
-                    eyebrow="Positioning"
-                    title="Target Versus Current Exposure"
-                    action="derived from cycle artifacts"
-                  />
-                  <div className="signal-grid h-80 border border-[var(--border)] p-3">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <LineChart data={metrics.positionSeries}>
-                        <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
-                        <XAxis
-                          dataKey="label"
-                          tick={{ fill: "#90a4bf", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={false}
-                        />
-                        <YAxis
-                          domain={[-1, 1]}
-                          tick={{ fill: "#90a4bf", fontSize: 11 }}
-                          tickLine={false}
-                          axisLine={false}
-                          width={40}
-                        />
-                        <Tooltip
-                          contentStyle={{
-                            border: "1px solid rgba(135, 162, 196, 0.22)",
-                            background: "rgba(8, 12, 20, 0.96)",
-                            color: "#ecf4ff",
-                          }}
-                        />
-                        <Line type="monotone" dataKey="target" stroke="#8fd6ff" strokeWidth={2.5} dot={false} />
-                        <Line
-                          type="monotone"
-                          dataKey="current"
-                          stroke="#9bf6cf"
-                          strokeWidth={2}
-                          dot={false}
-                        />
-                      </LineChart>
-                    </ResponsiveContainer>
+                  <div className="grid gap-4 xl:grid-cols-3">
+                  <Panel className="p-5 xl:col-span-2">
+                    <SectionHeader
+                      eyebrow="Performance"
+                      title="Equity Curve"
+                      action={`${metrics.equitySeries.length} canonical points`}
+                    />
+                    <div className="signal-grid h-80 border border-[var(--border)] p-3">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart data={metrics.equitySeries}>
+                          <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                          <XAxis
+                            dataKey="label"
+                            tick={{ fill: "#90a4bf", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                          />
+                          <YAxis
+                            tick={{ fill: "#90a4bf", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                            width={80}
+                          />
+                          <Tooltip
+                            contentStyle={{
+                              border: "1px solid rgba(135, 162, 196, 0.22)",
+                              background: "rgba(8, 12, 20, 0.96)",
+                              color: "#ecf4ff",
+                            }}
+                          />
+                          <Line type="monotone" dataKey="value" stroke="#8fd6ff" strokeWidth={2.5} dot={false} />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </Panel>
+
+                  <Panel className="p-5">
+                    <SectionHeader
+                      eyebrow="Risk"
+                      title="Drawdown"
+                      action={formatPercent(metrics.maxDrawdownPct)}
+                    />
+                    <div className="signal-grid h-80 border border-[var(--border)] p-3">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart data={metrics.drawdownSeries}>
+                          <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                          <XAxis
+                            dataKey="label"
+                            tick={{ fill: "#90a4bf", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                          />
+                          <YAxis
+                            tick={{ fill: "#90a4bf", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                            width={80}
+                          />
+                          <Tooltip
+                            contentStyle={{
+                              border: "1px solid rgba(135, 162, 196, 0.22)",
+                              background: "rgba(8, 12, 20, 0.96)",
+                              color: "#ecf4ff",
+                            }}
+                          />
+                          <Line type="monotone" dataKey="value" stroke="#ff6d7b" strokeWidth={2.5} dot={false} />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </Panel>
+
+                  <Panel className="p-5 xl:col-span-2">
+                    <SectionHeader
+                      eyebrow="Exposure"
+                      title="Absolute Exposure Timeline"
+                      action={`${formatPercent(metrics.avgAbsExposurePct)} average / ${formatPercent(metrics.maxAbsExposurePct)} peak`}
+                    />
+                    <div className="signal-grid h-72 border border-[var(--border)] p-3">
+                      <ResponsiveContainer width="100%" height="100%">
+                        <LineChart data={metrics.exposureSeries}>
+                          <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                          <XAxis
+                            dataKey="label"
+                            tick={{ fill: "#90a4bf", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                          />
+                          <YAxis
+                            tickFormatter={(value) => `${Math.round(value * 100)}%`}
+                            tick={{ fill: "#90a4bf", fontSize: 11 }}
+                            tickLine={false}
+                            axisLine={false}
+                            width={56}
+                          />
+                          <Tooltip
+                            contentStyle={{
+                              border: "1px solid rgba(135, 162, 196, 0.22)",
+                              background: "rgba(8, 12, 20, 0.96)",
+                              color: "#ecf4ff",
+                            }}
+                            formatter={(value) => formatTooltipPercent(value)}
+                          />
+                          <Line type="monotone" dataKey="value" stroke="#9bf6cf" strokeWidth={2.5} dot={false} />
+                        </LineChart>
+                      </ResponsiveContainer>
+                    </div>
+                  </Panel>
+
+                  <Panel className="p-5">
+                    <SectionHeader eyebrow="Activity" title="Decision Mix" action={`${Object.keys(metrics.decisionCounts).length} reason codes`} />
+                    <div className="space-y-3">
+                      {Object.entries(metrics.decisionCounts).length > 0 ? (
+                        Object.entries(metrics.decisionCounts)
+                          .sort((left, right) => right[1] - left[1])
+                          .map(([code, count]) => (
+                            <div
+                              key={code}
+                              className="flex items-center justify-between border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-3 text-sm"
+                            >
+                              <span className="text-[var(--text)]">{code}</span>
+                              <span className="mono text-[var(--accent)]">{count}</span>
+                            </div>
+                          ))
+                      ) : (
+                        <div className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-5 text-sm leading-6 text-[var(--muted)]">
+                          Decision counts will appear once the latest run has a canonical analysis payload.
+                        </div>
+                      )}
+                    </div>
+                  </Panel>
                   </div>
-                </Panel>
-              </div>
+                </div>
+              ) : (
+                <PerformanceUnavailablePanel />
+              )}
 
               <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
                 <Panel className="p-5">

--- a/apps/web/components/run-detail.test.tsx
+++ b/apps/web/components/run-detail.test.tsx
@@ -10,6 +10,16 @@ vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
 }));
 
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  LineChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CartesianGrid: () => null,
+  Line: () => null,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
 vi.mock("@/lib/perpfut-api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/perpfut-api")>("@/lib/perpfut-api");
   return {
@@ -119,12 +129,55 @@ describe("RunDetail", () => {
           ],
         };
       }
+      if (path.includes("/analysis")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          mode: "paper",
+          product_id: "BTC-PERP-INTX",
+          strategy_id: "momentum",
+          started_at: "2026-03-22T02:00:00Z",
+          ended_at: "2026-03-22T02:10:00Z",
+          cycle_count: 12,
+          starting_equity_usdc: 10000,
+          ending_equity_usdc: 10125,
+          realized_pnl_usdc: 80,
+          unrealized_pnl_usdc: 45,
+          total_pnl_usdc: 125,
+          total_return_pct: 0.0125,
+          max_drawdown_usdc: 40,
+          max_drawdown_pct: 0.004,
+          turnover_usdc: 5200,
+          fill_count: 3,
+          trade_count: 3,
+          avg_abs_exposure_pct: 0.22,
+          max_abs_exposure_pct: 0.35,
+          decision_counts: {
+            filled: 3,
+            below_rebalance_threshold: 9,
+          },
+          equity_series: [
+            { label: "cycle-1", value: 10000 },
+            { label: "cycle-12", value: 10125 },
+          ],
+          drawdown_series: [
+            { label: "cycle-1", value: 0 },
+            { label: "cycle-12", value: 40 },
+          ],
+          exposure_series: [
+            { label: "cycle-1", value: 0.1 },
+            { label: "cycle-12", value: 0.22 },
+          ],
+        };
+      }
       throw new Error(`unexpected path ${path}`);
     });
 
     renderRunDetail();
 
     expect(await screen.findByText("Run Detail: 20260322T020000000000Z_demo")).toBeInTheDocument();
+    expect(screen.getByText("Canonical Analysis Summary")).toBeInTheDocument();
+    expect(screen.getByText("+1.25%")).toBeInTheDocument();
+    expect(screen.getByText("Absolute Exposure Timeline")).toBeInTheDocument();
     expect(screen.getByText("Recent Fill Tape")).toBeInTheDocument();
     expect(screen.getByText("BUY")).toBeInTheDocument();
     expect(screen.getByText("Latest Decision Snapshot")).toBeInTheDocument();
@@ -169,6 +222,34 @@ describe("RunDetail", () => {
           items: [],
         };
       }
+      if (path.includes("/analysis")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          mode: "paper",
+          product_id: "BTC-PERP-INTX",
+          strategy_id: null,
+          started_at: "2026-03-22T02:00:00Z",
+          ended_at: "2026-03-22T02:00:00Z",
+          cycle_count: 0,
+          starting_equity_usdc: 10000,
+          ending_equity_usdc: 10000,
+          realized_pnl_usdc: 0,
+          unrealized_pnl_usdc: 0,
+          total_pnl_usdc: 0,
+          total_return_pct: 0,
+          max_drawdown_usdc: 0,
+          max_drawdown_pct: 0,
+          turnover_usdc: 0,
+          fill_count: 0,
+          trade_count: 0,
+          avg_abs_exposure_pct: 0,
+          max_abs_exposure_pct: 0,
+          decision_counts: {},
+          equity_series: [],
+          drawdown_series: [],
+          exposure_series: [],
+        };
+      }
       throw new Error(`unexpected path ${path}`);
     });
 
@@ -178,5 +259,51 @@ describe("RunDetail", () => {
     expect(
       screen.getByText("No normalized decision summary is available in this checkpoint yet.")
     ).toBeInTheDocument();
+  });
+
+  it("keeps the run detail readable when canonical analysis is unavailable", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path.endsWith("/manifest")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          data: {
+            mode: "paper",
+            product_id: "BTC-PERP-INTX",
+          },
+        };
+      }
+      if (path.endsWith("/state")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          data: {
+            equity_usdc: 10125,
+            execution_summary: {
+              action: "filled",
+              reason_code: "filled",
+              reason_message: "Cycle placed and filled a rebalance order.",
+              summary: "Filled a rebalance order toward the target position.",
+            },
+          },
+        };
+      }
+      if (path.includes("/fills") || path.includes("/positions") || path.includes("/events")) {
+        return {
+          run_id: "20260322T020000000000Z_demo",
+          count: 0,
+          items: [],
+        };
+      }
+      if (path.includes("/analysis")) {
+        throw new ApiError("analysis inputs not found", 404);
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderRunDetail();
+
+    expect(await screen.findByText("Run Detail: 20260322T020000000000Z_demo")).toBeInTheDocument();
+    expect(screen.getByText("Canonical Analysis Unavailable")).toBeInTheDocument();
+    expect(screen.getByText("analysis inputs not found")).toBeInTheDocument();
+    expect(screen.getByText("Latest Decision Snapshot")).toBeInTheDocument();
   });
 });

--- a/apps/web/components/run-detail.tsx
+++ b/apps/web/components/run-detail.tsx
@@ -2,8 +2,29 @@
 
 import Link from "next/link";
 import useSWR from "swr";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
-import { fetchJson, type ArtifactDocumentResponse, type ArtifactListResponse } from "@/lib/perpfut-api";
+import {
+  buildAnalysisMetrics,
+  formatCount,
+  formatMoney,
+  formatPercent,
+  formatSignedPercent,
+} from "@/lib/dashboard-metrics";
+import {
+  fetchJson,
+  type ArtifactDocumentResponse,
+  type ArtifactListResponse,
+  type RunAnalysisResponse,
+} from "@/lib/perpfut-api";
 
 
 function DetailPanel({
@@ -212,6 +233,158 @@ function DecisionSnapshot({ stateData }: { stateData: Record<string, unknown> })
   );
 }
 
+function formatTooltipPercent(value: unknown): string {
+  return typeof value === "number" ? `${(value * 100).toFixed(2)}%` : "--";
+}
+
+function PerformanceSnapshot({ analysis }: { analysis: RunAnalysisResponse }) {
+  const metrics = buildAnalysisMetrics(analysis);
+
+  return (
+    <>
+      <DetailPanel className="p-5">
+        <DetailHeader
+          eyebrow="Performance"
+          title="Canonical Analysis Summary"
+          action={`${formatCount(metrics.cycleCount)} cycles`}
+        />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <DetailMetric
+            label="Total Return"
+            value={formatSignedPercent(metrics.totalReturnPct)}
+            tone="accent"
+          />
+          <DetailMetric label="Total P&L" value={formatMoney(metrics.totalPnlUsd)} tone="accent" />
+          <DetailMetric
+            label="Max Drawdown"
+            value={`${formatPercent(metrics.maxDrawdownPct)} / ${formatMoney(metrics.maxDrawdownUsd)}`}
+            tone="danger"
+          />
+          <DetailMetric
+            label="Turnover / Trades"
+            value={`${formatMoney(metrics.turnoverUsd)} / ${formatCount(metrics.tradeCount ?? metrics.fillCount)}`}
+            tone="warning"
+          />
+          <DetailMetric
+            label="Exposure"
+            value={`${formatPercent(metrics.avgAbsExposurePct)} avg / ${formatPercent(metrics.maxAbsExposurePct)} peak`}
+          />
+        </div>
+      </DetailPanel>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <DetailPanel className="p-5 xl:col-span-2">
+          <DetailHeader eyebrow="Performance" title="Equity Curve" action={`${metrics.equitySeries.length} points`} />
+          <div className="signal-grid h-72 border border-[var(--border)] p-3">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={metrics.equitySeries}>
+                <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                <XAxis dataKey="label" tick={{ fill: "#90a4bf", fontSize: 11 }} tickLine={false} axisLine={false} />
+                <YAxis tick={{ fill: "#90a4bf", fontSize: 11 }} tickLine={false} axisLine={false} width={80} />
+                <Tooltip
+                  contentStyle={{
+                    border: "1px solid rgba(135, 162, 196, 0.22)",
+                    background: "rgba(8, 12, 20, 0.96)",
+                    color: "#ecf4ff",
+                  }}
+                />
+                <Line type="monotone" dataKey="value" stroke="#8fd6ff" strokeWidth={2.5} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </DetailPanel>
+
+        <DetailPanel className="p-5">
+          <DetailHeader eyebrow="Risk" title="Drawdown" action={formatPercent(metrics.maxDrawdownPct)} />
+          <div className="signal-grid h-72 border border-[var(--border)] p-3">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={metrics.drawdownSeries}>
+                <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                <XAxis dataKey="label" tick={{ fill: "#90a4bf", fontSize: 11 }} tickLine={false} axisLine={false} />
+                <YAxis tick={{ fill: "#90a4bf", fontSize: 11 }} tickLine={false} axisLine={false} width={80} />
+                <Tooltip
+                  contentStyle={{
+                    border: "1px solid rgba(135, 162, 196, 0.22)",
+                    background: "rgba(8, 12, 20, 0.96)",
+                    color: "#ecf4ff",
+                  }}
+                />
+                <Line type="monotone" dataKey="value" stroke="#ff6d7b" strokeWidth={2.5} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </DetailPanel>
+
+        <DetailPanel className="p-5 xl:col-span-2">
+          <DetailHeader
+            eyebrow="Exposure"
+            title="Absolute Exposure Timeline"
+            action={`${formatPercent(metrics.avgAbsExposurePct)} avg / ${formatPercent(metrics.maxAbsExposurePct)} peak`}
+          />
+          <div className="signal-grid h-72 border border-[var(--border)] p-3">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={metrics.exposureSeries}>
+                <CartesianGrid stroke="rgba(143,214,255,0.1)" vertical={false} />
+                <XAxis dataKey="label" tick={{ fill: "#90a4bf", fontSize: 11 }} tickLine={false} axisLine={false} />
+                <YAxis
+                  tickFormatter={(value) => `${Math.round(value * 100)}%`}
+                  tick={{ fill: "#90a4bf", fontSize: 11 }}
+                  tickLine={false}
+                  axisLine={false}
+                  width={56}
+                />
+                <Tooltip
+                  contentStyle={{
+                    border: "1px solid rgba(135, 162, 196, 0.22)",
+                    background: "rgba(8, 12, 20, 0.96)",
+                    color: "#ecf4ff",
+                  }}
+                  formatter={(value) => formatTooltipPercent(value)}
+                />
+                <Line type="monotone" dataKey="value" stroke="#9bf6cf" strokeWidth={2.5} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        </DetailPanel>
+
+        <DetailPanel className="p-5">
+          <DetailHeader eyebrow="Activity" title="Decision Counts" action={`${Object.keys(metrics.decisionCounts).length} reason codes`} />
+          <div className="space-y-3">
+            {Object.entries(metrics.decisionCounts).length > 0 ? (
+              Object.entries(metrics.decisionCounts)
+                .sort((left, right) => right[1] - left[1])
+                .map(([code, count]) => (
+                  <div
+                    key={code}
+                    className="flex items-center justify-between border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-3 text-sm"
+                  >
+                    <span className="text-[var(--text)]">{code}</span>
+                    <span className="mono text-[var(--accent)]">{count}</span>
+                  </div>
+                ))
+            ) : (
+              <div className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-5 text-sm leading-6 text-[var(--muted)]">
+                No canonical decision counts were recorded for this run.
+              </div>
+            )}
+          </div>
+        </DetailPanel>
+      </div>
+    </>
+  );
+}
+
+function PerformanceUnavailable({ message }: { message: string }) {
+  return (
+    <DetailPanel className="p-5">
+      <DetailHeader eyebrow="Performance" title="Canonical Analysis Unavailable" />
+      <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+        {message}
+      </div>
+    </DetailPanel>
+  );
+}
+
 export function RunDetail({ runId }: { runId: string }) {
   const manifest = useSWR<ArtifactDocumentResponse>(
     `/runs/${runId}/manifest`,
@@ -238,10 +411,19 @@ export function RunDetail({ runId }: { runId: string }) {
     (path) => fetchJson(path),
     { refreshInterval: 2_000 }
   );
+  const analysis = useSWR<RunAnalysisResponse>(
+    `/runs/${runId}/analysis`,
+    (path) => fetchJson(path),
+    { refreshInterval: 2_000 }
+  );
 
   const error = manifest.error ?? state.error ?? fills.error ?? positions.error ?? events.error;
   const isLoading =
-    manifest.isLoading || state.isLoading || fills.isLoading || positions.isLoading || events.isLoading;
+    manifest.isLoading ||
+    state.isLoading ||
+    fills.isLoading ||
+    positions.isLoading ||
+    events.isLoading;
 
   if (error) {
     return (
@@ -277,8 +459,8 @@ export function RunDetail({ runId }: { runId: string }) {
               </Link>
               <h1 className="mt-3 text-3xl font-semibold tracking-tight">Run Detail: {runId}</h1>
               <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--muted)]">
-                Read-only inspection of manifest, latest state, fills, position snapshots, and raw
-                operator events for a single artifact run.
+                Read-only inspection of canonical performance analysis, manifest, latest state,
+                fills, position snapshots, and raw operator events for a single artifact run.
               </p>
             </div>
             <div className="grid gap-2 text-xs uppercase tracking-[0.22em] text-[var(--muted)] sm:grid-cols-3">
@@ -311,6 +493,20 @@ export function RunDetail({ runId }: { runId: string }) {
         </div>
 
         <DecisionSnapshot stateData={stateData} />
+
+        {analysis.data ? (
+          <PerformanceSnapshot analysis={analysis.data} />
+        ) : analysis.isLoading ? (
+          <PerformanceUnavailable message="Canonical analysis is still loading for this run." />
+        ) : (
+          <PerformanceUnavailable
+            message={
+              analysis.error instanceof Error
+                ? analysis.error.message
+                : "Canonical analysis is not available for this run yet."
+            }
+          />
+        )}
 
         <div className="grid gap-4 xl:grid-cols-[1.1fr_0.9fr]">
           <DetailPanel className="p-5">

--- a/apps/web/lib/dashboard-metrics.ts
+++ b/apps/web/lib/dashboard-metrics.ts
@@ -1,151 +1,64 @@
-import type { DashboardOverviewResponse } from "@/lib/perpfut-api";
+import type { DashboardOverviewResponse, RunAnalysisResponse } from "@/lib/perpfut-api";
 
 
-type PositionState = {
-  quantity?: number;
-  mark_price?: number;
-  entry_price?: number | null;
-  collateral_usdc?: number;
-  realized_pnl_usdc?: number;
-};
-
-export type EquityPoint = {
+export type MetricSeriesPoint = {
   label: string;
-  equity: number;
-  realizedPnl: number;
-};
-
-export type PositionPoint = {
-  label: string;
-  target: number;
-  current: number;
+  value: number;
 };
 
 export type DashboardMetrics = {
-  equityUsd: number | null;
+  totalReturnPct: number | null;
+  totalPnlUsd: number | null;
   realizedPnlUsd: number | null;
   unrealizedPnlUsd: number | null;
-  quantity: number | null;
-  targetPosition: number | null;
-  lastSignalRaw: number | null;
+  maxDrawdownUsd: number | null;
+  maxDrawdownPct: number | null;
+  turnoverUsd: number | null;
   fillCount: number;
-  eventCount: number;
-  equitySeries: EquityPoint[];
-  positionSeries: PositionPoint[];
+  tradeCount: number | null;
+  avgAbsExposurePct: number | null;
+  maxAbsExposurePct: number | null;
+  cycleCount: number;
+  equitySeries: MetricSeriesPoint[];
+  drawdownSeries: MetricSeriesPoint[];
+  exposureSeries: MetricSeriesPoint[];
+  decisionCounts: Record<string, number>;
 };
 
-const DEFAULT_MAX_ABS_NOTIONAL = 20_000;
-
 export function buildDashboardMetrics(overview: DashboardOverviewResponse): DashboardMetrics {
-  const cycleEvents = overview.recent_events
-    .filter((event) => event.event_type === "cycle")
-    .slice()
-    .reverse();
+  return buildAnalysisMetrics(overview.latest_analysis);
+}
 
-  let inferredMaxAbsNotional = DEFAULT_MAX_ABS_NOTIONAL;
-  let lastCurrentPosition = 0;
-
-  const equitySeries: EquityPoint[] = [];
-  const positionSeries: PositionPoint[] = [];
-
-  for (const event of cycleEvents) {
-    const signal = asRecord(event.signal);
-    const orderIntent = asRecord(event.order_intent);
-    const position = asRecord(event.position);
-
-    const target = asNumber(signal?.target_position) ?? asNumber(event.target_position) ?? 0;
-    const rawValue = asNumber(signal?.raw_value);
-    const currentNotional = asNumber(orderIntent?.current_notional_usdc);
-    const targetNotional = asNumber(orderIntent?.target_notional_usdc);
-
-    if (targetNotional !== null && target !== 0) {
-      inferredMaxAbsNotional = Math.max(Math.abs(targetNotional / target), 1);
-    }
-
-    if (currentNotional !== null) {
-      lastCurrentPosition = currentNotional / inferredMaxAbsNotional;
-    }
-
-    const positionState = asPositionState(position);
-    const realizedPnl = positionState.realized_pnl_usdc ?? 0;
-    const unrealizedPnl = computeUnrealizedPnl(positionState);
-    const equity = (positionState.collateral_usdc ?? 0) + realizedPnl + unrealizedPnl;
-    const label = String(event.cycle_id ?? event.timestamp ?? event.event_type ?? positionSeries.length + 1);
-
-    equitySeries.push({
-      label,
-      equity,
-      realizedPnl,
-    });
-    positionSeries.push({
-      label,
-      target,
-      current: lastCurrentPosition,
-    });
-
-    if (rawValue !== null) {
-      // no-op: computed again from last cycle below
-    }
-  }
-
-  const latestCycle = cycleEvents.at(-1);
-  const latestSignal = asRecord(latestCycle?.signal);
-  const latestPosition = asPositionState(asRecord(latestCycle?.position));
-  const realizedPnlUsd = latestPosition.realized_pnl_usdc ?? null;
-  const unrealizedPnlUsd = computeUnrealizedPnl(latestPosition);
-  const equityUsd =
-    latestPosition.collateral_usdc !== undefined
-      ? (latestPosition.collateral_usdc ?? 0) + (realizedPnlUsd ?? 0) + unrealizedPnlUsd
-      : null;
-
+export function buildAnalysisMetrics(
+  analysis: RunAnalysisResponse | null | undefined
+): DashboardMetrics {
   return {
-    equityUsd,
-    realizedPnlUsd,
-    unrealizedPnlUsd,
-    quantity: latestPosition.quantity ?? null,
-    targetPosition: asNumber(latestSignal?.target_position),
-    lastSignalRaw: asNumber(latestSignal?.raw_value),
-    fillCount: overview.recent_fills.length,
-    eventCount: overview.recent_events.length,
-    equitySeries,
-    positionSeries,
+    totalReturnPct: analysis?.total_return_pct ?? null,
+    totalPnlUsd: analysis?.total_pnl_usdc ?? null,
+    realizedPnlUsd: analysis?.realized_pnl_usdc ?? null,
+    unrealizedPnlUsd: analysis?.unrealized_pnl_usdc ?? null,
+    maxDrawdownUsd: analysis?.max_drawdown_usdc ?? null,
+    maxDrawdownPct: analysis?.max_drawdown_pct ?? null,
+    turnoverUsd: analysis?.turnover_usdc ?? null,
+    fillCount: analysis?.fill_count ?? 0,
+    tradeCount: analysis?.trade_count ?? null,
+    avgAbsExposurePct: analysis?.avg_abs_exposure_pct ?? null,
+    maxAbsExposurePct: analysis?.max_abs_exposure_pct ?? null,
+    cycleCount: analysis?.cycle_count ?? 0,
+    equitySeries: toMetricSeries(analysis?.equity_series),
+    drawdownSeries: toMetricSeries(analysis?.drawdown_series),
+    exposureSeries: toMetricSeries(analysis?.exposure_series),
+    decisionCounts: analysis?.decision_counts ?? {},
   };
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function asNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function asPositionState(record: Record<string, unknown> | null): PositionState {
-  return {
-    quantity: asOptionalNumber(record?.quantity),
-    mark_price: asOptionalNumber(record?.mark_price),
-    entry_price: asOptionalNumber(record?.entry_price),
-    collateral_usdc: asOptionalNumber(record?.collateral_usdc),
-    realized_pnl_usdc: asOptionalNumber(record?.realized_pnl_usdc),
-  };
-}
-
-function computeUnrealizedPnl(state: PositionState): number {
-  if (
-    state.quantity === undefined ||
-    state.entry_price === undefined ||
-    state.entry_price === null ||
-    state.mark_price === undefined
-  ) {
-    return 0;
-  }
-  return (state.mark_price - state.entry_price) * state.quantity;
-}
-
-function asOptionalNumber(value: unknown): number | undefined {
-  return asNumber(value) ?? undefined;
+function toMetricSeries(
+  points: { label: string; value: number }[] | null | undefined
+): MetricSeriesPoint[] {
+  return (points ?? []).map((point) => ({
+    label: point.label,
+    value: point.value,
+  }));
 }
 
 export function formatMoney(value: number | null): string {
@@ -164,6 +77,30 @@ export function formatSigned(value: number | null, digits = 2): string {
     return "--";
   }
   return `${value > 0 ? "+" : ""}${value.toFixed(digits)}`;
+}
+
+export function formatPercent(value: number | null, digits = 2): string {
+  if (value === null) {
+    return "--";
+  }
+  return `${(value * 100).toFixed(digits)}%`;
+}
+
+export function formatSignedPercent(value: number | null, digits = 2): string {
+  if (value === null) {
+    return "--";
+  }
+  const percentage = (value * 100).toFixed(digits);
+  return `${value > 0 ? "+" : ""}${percentage}%`;
+}
+
+export function formatCount(value: number | null): string {
+  if (value === null) {
+    return "--";
+  }
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+  }).format(value);
 }
 
 export function formatTimestamp(value: string | null): string {


### PR DESCRIPTION
Closes #37

## Summary
- move overview and run detail reporting onto the canonical analysis payload
- replace event-derived PnL and exposure charts with analysis-backed performance views
- extend frontend tests for the new reporting contract

## Testing
- cd apps/web && npm run lint
- cd apps/web && npm run test
- cd apps/web && npm run build