### PR TITLE
Document performance reporting workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,22 @@ npm run dev
 ```
 
 The frontend polls the API every 2 seconds. It is local-only, currently focuses
-on monitoring and artifact drill-down, and keeps live mode read-only. Paper-run
-control routes already exist in the API and will be wired into the UI in the
-next frontend step.
+on monitoring and artifact drill-down, keeps live mode read-only, and now reads
+canonical performance analysis for overview and run-detail reporting.
+
+## Performance Inspection
+
+Inspect the latest paper run from the CLI:
+
+```bash
+python3 -m perpfut analyze --mode paper
+```
+
+The same canonical analysis is available:
+
+- from the API at `GET /api/runs/{runId}/analysis`
+- in the dashboard overview via `latest_analysis`
+- in the run detail page at `/runs/<run_id>`
 
 ## Design Principles
 
@@ -84,3 +97,4 @@ next frontend step.
 - Runbook: `docs/runbook.md`
 - MVP readiness gates: `docs/mvp-readiness.md`
 - Operator API and UI contract: `docs/operator-api.md`
+- Performance inspection guide: `docs/performance-reporting.md`

--- a/apps/web/components/operator-shell.tsx
+++ b/apps/web/components/operator-shell.tsx
@@ -757,8 +757,8 @@ export function OperatorShell() {
                       change={`${formatMoney(metrics.maxDrawdownUsd)} worst peak-to-trough`}
                     />
                     <StatCard
-                      label="Turnover / Exposure"
-                      value={`${formatCount(metrics.tradeCount ?? metrics.fillCount)} trades`}
+                      label="Fill Activity / Exposure"
+                      value={`${formatCount(metrics.fillCount)} fills`}
                       change={`${formatMoney(metrics.turnoverUsd)} turnover / ${formatPercent(metrics.avgAbsExposurePct)} avg exposure`}
                       tone="warning"
                     />

--- a/apps/web/components/run-detail.tsx
+++ b/apps/web/components/run-detail.tsx
@@ -261,8 +261,8 @@ function PerformanceSnapshot({ analysis }: { analysis: RunAnalysisResponse }) {
             tone="danger"
           />
           <DetailMetric
-            label="Turnover / Trades"
-            value={`${formatMoney(metrics.turnoverUsd)} / ${formatCount(metrics.tradeCount ?? metrics.fillCount)}`}
+            label="Turnover / Fill Rows"
+            value={`${formatMoney(metrics.turnoverUsd)} / ${formatCount(metrics.fillCount)}`}
             tone="warning"
           />
           <DetailMetric

--- a/apps/web/lib/dashboard-metrics.test.ts
+++ b/apps/web/lib/dashboard-metrics.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAnalysisMetrics } from "@/lib/dashboard-metrics";
+
+
+describe("buildAnalysisMetrics", () => {
+  it("maps canonical analysis payloads into chart and KPI metrics", () => {
+    const metrics = buildAnalysisMetrics({
+      run_id: "run-1",
+      mode: "paper",
+      product_id: "BTC-PERP-INTX",
+      strategy_id: "momentum",
+      started_at: "2026-03-21T01:00:00Z",
+      ended_at: "2026-03-21T02:00:00Z",
+      cycle_count: 12,
+      starting_equity_usdc: 10000,
+      ending_equity_usdc: 10125,
+      realized_pnl_usdc: 80,
+      unrealized_pnl_usdc: 45,
+      total_pnl_usdc: 125,
+      total_return_pct: 0.0125,
+      max_drawdown_usdc: 40,
+      max_drawdown_pct: 0.004,
+      turnover_usdc: 5200,
+      fill_count: 3,
+      trade_count: 3,
+      avg_abs_exposure_pct: 0.22,
+      max_abs_exposure_pct: 0.35,
+      decision_counts: {
+        filled: 3,
+        below_rebalance_threshold: 9,
+      },
+      equity_series: [
+        { label: "cycle-1", value: 10000 },
+        { label: "cycle-12", value: 10125 },
+      ],
+      drawdown_series: [
+        { label: "cycle-1", value: 0 },
+        { label: "cycle-12", value: 40 },
+      ],
+      exposure_series: [
+        { label: "cycle-1", value: 0.1 },
+        { label: "cycle-12", value: 0.22 },
+      ],
+    });
+
+    expect(metrics.totalReturnPct).toBe(0.0125);
+    expect(metrics.totalPnlUsd).toBe(125);
+    expect(metrics.cycleCount).toBe(12);
+    expect(metrics.turnoverUsd).toBe(5200);
+    expect(metrics.equitySeries).toEqual([
+      { label: "cycle-1", value: 10000 },
+      { label: "cycle-12", value: 10125 },
+    ]);
+    expect(metrics.decisionCounts).toEqual({
+      filled: 3,
+      below_rebalance_threshold: 9,
+    });
+  });
+
+  it("leaves KPI values unknown when analysis is absent", () => {
+    const metrics = buildAnalysisMetrics(null);
+
+    expect(metrics.totalReturnPct).toBeNull();
+    expect(metrics.totalPnlUsd).toBeNull();
+    expect(metrics.tradeCount).toBeNull();
+    expect(metrics.cycleCount).toBe(0);
+    expect(metrics.equitySeries).toEqual([]);
+    expect(metrics.decisionCounts).toEqual({});
+  });
+});

--- a/docs/performance-reporting.md
+++ b/docs/performance-reporting.md
@@ -1,0 +1,105 @@
+# Performance Reporting
+
+`perpfut` exposes one canonical performance contract for run analysis. The same
+payload shape is used by the CLI, the operator API, and the Next.js dashboard.
+
+## What The Analysis Contains
+
+Canonical run analysis includes:
+
+- run identity: `run_id`, `mode`, `product_id`, `strategy_id`
+- timing: `started_at`, `ended_at`, `cycle_count`
+- PnL and return: `starting_equity_usdc`, `ending_equity_usdc`, `realized_pnl_usdc`, `unrealized_pnl_usdc`, `total_pnl_usdc`, `total_return_pct`
+- risk and activity: `max_drawdown_usdc`, `max_drawdown_pct`, `turnover_usdc`, `fill_count`, `trade_count`
+- exposure: `avg_abs_exposure_pct`, `max_abs_exposure_pct`
+- decision mix: `decision_counts`
+- chart series: `equity_series`, `drawdown_series`, `exposure_series`
+
+The canonical payload is derived from run artifacts on demand. It is not stored
+in a database and does not depend on in-memory engine state.
+
+`trade_count` is reserved for future order-level reporting. Today it should be
+treated as fill-derived activity rather than true exchange-order count, so the
+operator-facing surfaces use `fill_count`.
+
+## CLI
+
+Analyze a specific run:
+
+```bash
+python3 -m perpfut analyze --run-id 20260322T020000000000Z_demo
+```
+
+Analyze the latest paper run:
+
+```bash
+python3 -m perpfut analyze --mode paper
+```
+
+Analyze the latest live run for a product:
+
+```bash
+python3 -m perpfut analyze --mode live --product-id BTC-PERP-INTX
+```
+
+CLI output is JSON. The most important fields for a quick read are:
+
+- `total_pnl_usdc`
+- `total_return_pct`
+- `max_drawdown_pct`
+- `turnover_usdc`
+- `fill_count`
+- `avg_abs_exposure_pct`
+
+If analysis inputs are missing or malformed, the CLI exits with a user-facing
+error instead of printing a traceback.
+
+## API
+
+Performance reporting is available through:
+
+- `GET /api/runs/{runId}/analysis`
+- `GET /api/dashboard/overview?mode=paper|live`
+
+The dashboard overview includes:
+
+- `latest_run`
+- `latest_state`
+- `latest_decision`
+- `latest_analysis`
+
+Example:
+
+```bash
+curl -s http://127.0.0.1:8000/api/runs/20260322T020000000000Z_demo/analysis | jq
+```
+
+Use the overview route when you want the latest matching run for a mode. Use the
+per-run analysis route when you want a stable drill-down payload.
+
+## UI
+
+The operator console reads the canonical analysis payload in two places:
+
+- `/`
+  - top-line performance cards
+  - equity curve
+  - drawdown chart
+  - exposure chart
+  - decision-count summary
+- `/runs/<run_id>`
+  - canonical analysis summary
+  - run-level equity, drawdown, and exposure charts
+  - decision-count summary alongside raw artifacts
+
+If canonical analysis is unavailable for a run, the UI keeps the artifact pages
+readable and shows an explicit reporting fallback instead of failing the whole
+view.
+
+## Recommended Review Flow
+
+1. Confirm the run exists with `python3 -m perpfut runs --limit 5`.
+2. Inspect final checkpoint state with `python3 -m perpfut state --mode paper`.
+3. Analyze the run with `python3 -m perpfut analyze --run-id ...`.
+4. Open the dashboard and compare the cards/charts with the CLI output.
+5. Use the run detail page for drill-down into fills, events, and decision mix.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -9,6 +9,10 @@
 5. Inspect artifacts:
    - `python3 -m perpfut runs --limit 5`
    - `python3 -m perpfut state --mode paper`
+6. Inspect canonical performance:
+   - `python3 -m perpfut analyze --mode paper`
+   - `curl -s http://127.0.0.1:8000/api/dashboard/overview?mode=paper | jq '.latest_analysis'`
+   - open `http://127.0.0.1:3000` for the overview and `/runs/<run_id>` for drill-down
 
 ## Live Mode
 
@@ -36,3 +40,9 @@ Live sequence:
 - If live preflight fails, do not start `perpfut live`.
 - On restart, the engine loads the latest matching live checkpoint, reconciles against Coinbase before trading, and logs `resume_mismatch` if local checkpoint notional differs from exchange truth.
 - Review `events.ndjson` for `halt`, `resume_loaded`, `resume_mismatch`, `order_preview`, `order_submit`, and `order_fill` before continuing.
+
+## Reporting Notes
+
+- CLI, API, and UI now share the same canonical run analysis payload.
+- If a run is older or incomplete and cannot be analyzed, the dashboard still keeps artifact views readable and shows a reporting fallback instead of crashing.
+- See `docs/performance-reporting.md` for the full reporting contract and operator workflow.

--- a/src/perpfut/analysis.py
+++ b/src/perpfut/analysis.py
@@ -53,10 +53,12 @@ def analyze_run(run_dir: Path) -> RunAnalysis:
     fills = _collect_fill_rows(run_dir, events)
 
     max_abs_notional = _resolve_max_abs_notional(config)
+    configured_starting_equity = _resolve_starting_equity(config, _resolve_ending_equity(state))
     equity_series = _build_equity_series(positions)
+    equity_series = _prepend_configured_starting_equity(equity_series, configured_starting_equity)
     if not equity_series:
         ending_equity = _resolve_ending_equity(state)
-        starting_equity = _resolve_starting_equity(config, ending_equity)
+        starting_equity = configured_starting_equity
         equity_series = [SeriesPoint(label="start", value=starting_equity)]
         if str(state.get("cycle_id") or "latest") != "start" or ending_equity != starting_equity:
             equity_series.append(
@@ -155,6 +157,18 @@ def _build_drawdown_series(equity_series: list[SeriesPoint]) -> list[SeriesPoint
         peak = max(peak, point.value)
         points.append(SeriesPoint(label=point.label, value=max(peak - point.value, 0.0)))
     return points
+
+
+def _prepend_configured_starting_equity(
+    equity_series: list[SeriesPoint],
+    starting_equity: float,
+) -> list[SeriesPoint]:
+    if not equity_series:
+        return equity_series
+    first_point = equity_series[0]
+    if abs(first_point.value - starting_equity) <= 1e-12:
+        return equity_series
+    return [SeriesPoint(label="start", value=starting_equity), *equity_series]
 
 
 def _compute_max_drawdown_pct(equity_series: list[SeriesPoint]) -> float:

--- a/src/perpfut/run_history.py
+++ b/src/perpfut/run_history.py
@@ -37,7 +37,12 @@ def find_latest_run(
             continue
         if require_state and not _has_readable_state(run_dir):
             continue
-        manifest = load_run_manifest(run_dir)
+        try:
+            manifest = load_run_manifest(run_dir)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(manifest, dict):
+            continue
         if mode is not None and manifest.get("mode") != mode:
             continue
         if product_id is not None and manifest.get("product_id") != product_id:
@@ -49,7 +54,13 @@ def find_latest_run(
 def summarize_runs(base_dir: Path, *, limit: int = 10) -> list[dict[str, Any]]:
     summaries = []
     for run_dir in list_runs(base_dir)[:limit]:
-        manifest = load_run_manifest(run_dir) if (run_dir / "manifest.json").exists() else {}
+        manifest = {}
+        if (run_dir / "manifest.json").exists():
+            try:
+                loaded = load_run_manifest(run_dir)
+            except (OSError, json.JSONDecodeError):
+                loaded = {}
+            manifest = loaded if isinstance(loaded, dict) else {}
         summaries.append(
             {
                 "run_id": run_dir.name,
@@ -71,7 +82,7 @@ def _has_readable_state(run_dir: Path) -> bool:
     if not state_path.exists():
         return False
     try:
-        _load_json(state_path)
+        payload = _load_json(state_path)
     except (OSError, json.JSONDecodeError):
         return False
-    return True
+    return isinstance(payload, dict)

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -181,3 +181,69 @@ def test_analyze_run_uses_live_state_fallbacks_when_positions_and_fills_are_abse
     assert analysis.turnover_usdc == 15.5
     assert analysis.avg_abs_exposure_pct == 0.2
     assert analysis.decision_counts == {"filled": 1}
+
+
+def test_analyze_run_prepends_configured_start_for_single_snapshot_positions(tmp_path) -> None:
+    run_dir = tmp_path / "20260322T020000000000Z_single"
+    run_dir.mkdir(parents=True)
+    _write_json(
+        run_dir / "manifest.json",
+        {
+            "run_id": run_dir.name,
+            "created_at": "2026-03-22T02:00:00Z",
+            "mode": "paper",
+            "product_id": "BTC-PERP-INTX",
+        },
+    )
+    _write_json(
+        run_dir / "config.json",
+        {
+            "simulation": {
+                "starting_collateral_usdc": 10000.0,
+                "max_leverage": 2.0,
+            }
+        },
+    )
+    _write_ndjson(
+        run_dir / "positions.ndjson",
+        [
+            {
+                "cycle_id": "cycle-0001",
+                "position": {
+                    "quantity": 0.5,
+                    "entry_price": 100.0,
+                    "mark_price": 110.0,
+                    "collateral_usdc": 10000.0,
+                    "realized_pnl_usdc": 20.0,
+                },
+            },
+        ],
+    )
+    _write_ndjson(
+        run_dir / "events.ndjson",
+        [
+            {"cycle_id": "cycle-0001", "timestamp": "2026-03-22T02:01:00Z", "execution_summary": {"reason_code": "filled"}},
+        ],
+    )
+    _write_json(
+        run_dir / "state.json",
+        {
+            "run_id": run_dir.name,
+            "cycle_id": "cycle-0001",
+            "position": {
+                "quantity": 0.5,
+                "entry_price": 100.0,
+                "mark_price": 110.0,
+                "collateral_usdc": 10000.0,
+                "realized_pnl_usdc": 20.0,
+            },
+        },
+    )
+
+    analysis = analyze_run(run_dir)
+
+    assert analysis.starting_equity_usdc == 10000.0
+    assert analysis.ending_equity_usdc == 10025.0
+    assert analysis.total_pnl_usdc == 25.0
+    assert analysis.total_return_pct == 0.0025
+    assert [point.label for point in analysis.equity_series] == ["start", "cycle-0001"]

--- a/tests/unit/test_api_cli.py
+++ b/tests/unit/test_api_cli.py
@@ -220,3 +220,181 @@ def test_analyze_main_exits_cleanly_when_state_json_shape_is_invalid(tmp_path) -
         assert str(exc) == f"invalid analysis inputs for run: {run_id}"
     else:
         raise AssertionError("expected SystemExit")
+
+
+def test_analyze_main_uses_latest_matching_run_when_run_id_is_omitted(tmp_path, capsys) -> None:
+    older_run = tmp_path / "20260322T010000000000Z_alpha"
+    newer_run = tmp_path / "20260322T020000000000Z_beta"
+    for run_dir, ending_equity in ((older_run, 10050.0), (newer_run, 10125.0)):
+        run_dir.mkdir(parents=True)
+        (run_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "run_id": run_dir.name,
+                    "created_at": "2026-03-21T01:00:00Z",
+                    "mode": "paper",
+                    "product_id": "BTC-PERP-INTX",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (run_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "simulation": {
+                        "starting_collateral_usdc": 10_000.0,
+                        "max_leverage": 2.0,
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        (run_dir / "state.json").write_text(
+            json.dumps(
+                {
+                    "run_id": run_dir.name,
+                    "cycle_id": "cycle-0001",
+                    "mode": "paper",
+                    "position": {
+                        "collateral_usdc": 10_000.0,
+                        "realized_pnl_usdc": ending_equity - 10_000.0,
+                        "quantity": 0.0,
+                        "entry_price": 100.0,
+                        "mark_price": 100.0,
+                    },
+                    "execution_summary": {
+                        "reason_code": "filled",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        (run_dir / "events.ndjson").write_text(
+            json.dumps(
+                {
+                    "cycle_id": "cycle-0001",
+                    "timestamp": "2026-03-21T01:00:00Z",
+                    "execution_summary": {
+                        "reason_code": "filled",
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (run_dir / "positions.ndjson").write_text(
+            json.dumps(
+                {
+                    "cycle_id": "cycle-0001",
+                    "position": {
+                        "collateral_usdc": 10_000.0,
+                        "realized_pnl_usdc": ending_equity - 10_000.0,
+                        "quantity": 0.0,
+                        "entry_price": 100.0,
+                        "mark_price": 100.0,
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    exit_code = main(["analyze", "--runs-dir", str(tmp_path), "--mode", "paper"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run_id"] == "20260322T020000000000Z_beta"
+    assert payload["ending_equity_usdc"] == 10125.0
+    assert payload["starting_equity_usdc"] == 10000.0
+    assert payload["total_pnl_usdc"] == 125.0
+    assert payload["total_return_pct"] == 0.0125
+
+
+def test_analyze_main_skips_latest_run_with_shape_invalid_manifest(tmp_path, capsys) -> None:
+    invalid_latest = tmp_path / "20260322T030000000000Z_invalid"
+    valid_latest = tmp_path / "20260322T020000000000Z_beta"
+    invalid_latest.mkdir(parents=True)
+    valid_latest.mkdir(parents=True)
+
+    (invalid_latest / "manifest.json").write_text("[1]\n", encoding="utf-8")
+    (invalid_latest / "state.json").write_text("{}", encoding="utf-8")
+
+    (valid_latest / "manifest.json").write_text(
+        json.dumps(
+            {
+                "run_id": valid_latest.name,
+                "created_at": "2026-03-21T01:00:00Z",
+                "mode": "paper",
+                "product_id": "BTC-PERP-INTX",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (valid_latest / "config.json").write_text(
+        json.dumps(
+            {
+                "simulation": {
+                    "starting_collateral_usdc": 10_000.0,
+                    "max_leverage": 2.0,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (valid_latest / "state.json").write_text(
+        json.dumps(
+            {
+                "run_id": valid_latest.name,
+                "cycle_id": "cycle-0001",
+                "mode": "paper",
+                "position": {
+                    "collateral_usdc": 10_000.0,
+                    "realized_pnl_usdc": 125.0,
+                    "quantity": 0.0,
+                    "entry_price": 100.0,
+                    "mark_price": 100.0,
+                },
+                "execution_summary": {
+                    "reason_code": "filled",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (valid_latest / "events.ndjson").write_text(
+        json.dumps(
+            {
+                "cycle_id": "cycle-0001",
+                "timestamp": "2026-03-21T01:00:00Z",
+                "execution_summary": {
+                    "reason_code": "filled",
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (valid_latest / "positions.ndjson").write_text(
+        json.dumps(
+            {
+                "cycle_id": "cycle-0001",
+                "position": {
+                    "collateral_usdc": 10_000.0,
+                    "realized_pnl_usdc": 125.0,
+                    "quantity": 0.0,
+                    "entry_price": 100.0,
+                    "mark_price": 100.0,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    exit_code = main(["analyze", "--runs-dir", str(tmp_path), "--mode", "paper"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["run_id"] == valid_latest.name
+    assert payload["starting_equity_usdc"] == 10000.0
+    assert payload["total_pnl_usdc"] == 125.0


### PR DESCRIPTION
Closes #38

## Summary
- add operator documentation for inspecting canonical run analysis from the CLI, API, and UI
- add targeted reporting coverage for latest-run CLI analysis and the frontend metrics adapter
- link the new reporting guide from the README and runbook

## Testing
- python3 -m pytest tests/unit/test_api_cli.py
- cd apps/web && npm run lint
- cd apps/web && npm run test
- cd apps/web && npm run build