### PR TITLE
Add registry-backed strategy selection

### DIFF
--- a/apps/web/lib/perpfut-api.ts
+++ b/apps/web/lib/perpfut-api.ts
@@ -13,6 +13,7 @@ export type RunsListResponse = {
 
 export type PaperRunRequest = {
   productId: string;
+  strategyId?: string;
   iterations: number;
   intervalSeconds: number;
   startingCollateralUsdc: number;
@@ -24,6 +25,7 @@ export type PaperRunStatusResponse = {
   started_at: string | null;
   run_id: string | null;
   product_id: string | null;
+  strategy_id: string | null;
   iterations: number | null;
   interval_seconds: number | null;
   starting_collateral_usdc: number | null;

--- a/docs/event-schema.md
+++ b/docs/event-schema.md
@@ -5,6 +5,13 @@ Each run writes immutable artifacts under `runs/<timestamp>_<gitsha>/`.
 ## Files
 
 - `manifest.json`: run metadata
+  - `run_id`
+  - `created_at`
+  - `mode`
+  - `product_id`
+  - `strategy_id`
+  - `git_sha`
+  - `resumed_from_run_id`
 - `config.json`: effective runtime config
 - `events.ndjson`: one high-level event per cycle
 - `fills.ndjson`: simulated or live fills

--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -46,11 +46,14 @@ Start requests accept:
 ```json
 {
   "productId": "BTC-PERP-INTX",
+  "strategyId": "momentum",
   "iterations": 1440,
   "intervalSeconds": 60,
   "startingCollateralUsdc": 10000
 }
 ```
+
+`strategyId` currently defaults to `momentum` when omitted.
 
 The service allows only one active paper run at a time.
 

--- a/src/perpfut/api/process_manager.py
+++ b/src/perpfut/api/process_manager.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from .schemas import PaperRunRequest, PaperRunStatusResponse
 from ..config import AppConfig
+from ..strategy_registry import validate_strategy_id
 
 
 class PaperRunConflictError(RuntimeError):
@@ -39,6 +40,7 @@ class PaperProcessMetadata:
     started_at: str
     run_id: str | None
     product_id: str
+    strategy_id: str
     iterations: int
     interval_seconds: int
     starting_collateral_usdc: float
@@ -64,6 +66,10 @@ class PaperProcessManager:
             current = self._status_locked()
             if current.active:
                 raise PaperRunConflictError("a paper run is already active")
+            try:
+                validate_strategy_id(request.strategy_id)
+            except ValueError as exc:
+                raise PaperRunStartError(str(exc)) from exc
 
             self.control_dir.mkdir(parents=True, exist_ok=True)
             with self.log_path.open("w", encoding="utf-8") as log_handle:
@@ -97,6 +103,7 @@ class PaperProcessManager:
                 started_at=datetime.now(timezone.utc).isoformat(),
                 run_id=None,
                 product_id=request.product_id,
+                strategy_id=request.strategy_id,
                 iterations=request.iterations,
                 interval_seconds=request.interval_seconds,
                 starting_collateral_usdc=request.starting_collateral_usdc,
@@ -137,6 +144,7 @@ class PaperProcessManager:
             {
                 "MODE": "paper",
                 "PRODUCT_ID": request.product_id,
+                "STRATEGY_ID": request.strategy_id,
                 "ITERATIONS": str(request.iterations),
                 "INTERVAL_SECONDS": str(request.interval_seconds),
                 "STARTING_COLLATERAL_USDC": str(request.starting_collateral_usdc),
@@ -163,6 +171,8 @@ class PaperProcessManager:
             raise PaperRunStateError("failed to read paper run metadata") from exc
         except json.JSONDecodeError as exc:
             raise PaperRunStateError("paper run metadata is corrupted") from exc
+        if isinstance(payload, dict) and "strategy_id" not in payload:
+            payload["strategy_id"] = "momentum"
         try:
             return PaperProcessMetadata(**payload)
         except TypeError as exc:
@@ -314,6 +324,7 @@ class PaperProcessManager:
             started_at=metadata.started_at,
             run_id=metadata.run_id,
             product_id=metadata.product_id,
+            strategy_id=metadata.strategy_id,
             iterations=metadata.iterations,
             interval_seconds=metadata.interval_seconds,
             starting_collateral_usdc=metadata.starting_collateral_usdc,

--- a/src/perpfut/api/schemas.py
+++ b/src/perpfut/api/schemas.py
@@ -128,6 +128,7 @@ class DashboardOverviewResponse(BaseModel):
 
 class PaperRunRequest(BaseModel):
     product_id: str = Field(alias="productId")
+    strategy_id: str = Field(alias="strategyId", default="momentum")
     iterations: int = Field(ge=1)
     interval_seconds: int = Field(alias="intervalSeconds", ge=0)
     starting_collateral_usdc: float = Field(alias="startingCollateralUsdc", gt=0)
@@ -143,6 +144,7 @@ class PaperRunStatusResponse(BaseModel):
     started_at: str | None = None
     run_id: str | None = None
     product_id: str | None = None
+    strategy_id: str | None = None
     iterations: int | None = None
     interval_seconds: int | None = None
     starting_collateral_usdc: float | None = None

--- a/src/perpfut/cli.py
+++ b/src/perpfut/cli.py
@@ -17,6 +17,7 @@ from .exchange_coinbase import CoinbasePrivateClient, CoinbasePublicClient
 from .live_execution import LiveExecutor
 from .preflight import run_preflight
 from .run_history import find_latest_run, load_run_manifest, load_run_state, summarize_runs
+from .strategy_registry import validate_strategy_id
 from .telemetry import ArtifactStore, configure_logging
 
 
@@ -114,6 +115,7 @@ def _run_paper(args: argparse.Namespace) -> int:
         interval_seconds=args.interval_seconds,
         runs_dir=args.runs_dir,
     )
+    _validate_strategy_config(config)
     artifact_store = ArtifactStore.create(config.runtime.runs_dir)
     artifact_store.write_metadata(config)
 
@@ -210,6 +212,7 @@ def _run_preflight(args: argparse.Namespace) -> int:
         product_id=args.product_id,
         runs_dir=args.runs_dir,
     )
+    _validate_strategy_config(config)
     portfolio_uuid = args.portfolio_uuid or config.coinbase.intx_portfolio_uuid
 
     with CoinbasePublicClient() as public_client:
@@ -250,6 +253,7 @@ def _run_live(args: argparse.Namespace) -> int:
         interval_seconds=args.interval_seconds,
         runs_dir=args.runs_dir,
     )
+    _validate_strategy_config(config)
     portfolio_uuid = args.portfolio_uuid or config.coinbase.intx_portfolio_uuid
     if not portfolio_uuid:
         raise SystemExit("set COINBASE_INTX_PORTFOLIO_UUID or pass --portfolio-uuid")
@@ -291,3 +295,10 @@ def _run_live(args: argparse.Namespace) -> int:
 def _run_api(args: argparse.Namespace) -> int:
     run_api_server(host=args.host, port=args.port)
     return 0
+
+
+def _validate_strategy_config(config: AppConfig) -> None:
+    try:
+        validate_strategy_id(config.strategy.strategy_id)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc

--- a/src/perpfut/config.py
+++ b/src/perpfut/config.py
@@ -26,6 +26,7 @@ def _env_mode(name: str, default: Mode) -> Mode:
 
 @dataclass(frozen=True, slots=True)
 class StrategyConfig:
+    strategy_id: str = "momentum"
     lookback_candles: int = 20
     signal_scale: float = 35.0
 
@@ -84,6 +85,7 @@ class AppConfig:
                 runs_dir=Path(os.getenv("RUNS_DIR", "runs")),
             ),
             strategy=StrategyConfig(
+                strategy_id=os.getenv("STRATEGY_ID", "momentum"),
                 lookback_candles=_env_int("LOOKBACK_CANDLES", 20),
                 signal_scale=_env_float("SIGNAL_SCALE", 35.0),
             ),

--- a/src/perpfut/engine.py
+++ b/src/perpfut/engine.py
@@ -23,8 +23,8 @@ from .risk import (
     clip_target_position,
     should_halt_for_drawdown,
 )
-from .signal_momentum import compute_signal
 from .sim import apply_fill, simulate_market_fill
+from .strategy_registry import compute_strategy_signal
 from .telemetry import ArtifactStore
 
 
@@ -65,10 +65,9 @@ class PaperEngine:
             candle_limit=self.config.strategy.lookback_candles,
         )
         marked_state = replace(self.state, mark_price=market.mid_price)
-        signal = compute_signal(
+        signal = compute_strategy_signal(
             market.candles,
-            lookback_candles=self.config.strategy.lookback_candles,
-            signal_scale=self.config.strategy.signal_scale,
+            self.config.strategy,
         )
         raw_target_position = signal.target_position
         target_position = clip_target_position(

--- a/src/perpfut/live_execution.py
+++ b/src/perpfut/live_execution.py
@@ -25,7 +25,7 @@ from .engine import (
     build_risk_decision,
 )
 from .risk import clip_target_position, should_halt_for_drawdown
-from .signal_momentum import compute_signal
+from .strategy_registry import compute_strategy_signal
 from .telemetry import ArtifactStore
 
 
@@ -162,10 +162,9 @@ class LiveExecutor:
         current_position = current_notional_usdc / self.config.max_abs_notional_usdc
         self._log_resume_mismatch_if_needed(cycle_id, current_notional_usdc)
 
-        signal = compute_signal(
+        signal = compute_strategy_signal(
             market.candles,
-            lookback_candles=self.config.strategy.lookback_candles,
-            signal_scale=self.config.strategy.signal_scale,
+            self.config.strategy,
         )
         raw_target_position = signal.target_position
         target_position = clip_target_position(

--- a/src/perpfut/signal_momentum.py
+++ b/src/perpfut/signal_momentum.py
@@ -6,6 +6,8 @@ from collections.abc import Sequence
 
 from .domain import Candle, SignalDecision
 
+STRATEGY_ID = "momentum"
+
 
 def compute_signal(
     candles: Sequence[Candle],
@@ -14,19 +16,19 @@ def compute_signal(
     signal_scale: float,
 ) -> SignalDecision:
     if len(candles) < lookback_candles:
-        return SignalDecision(strategy="momentum", raw_value=0.0, target_position=0.0)
+        return SignalDecision(strategy=STRATEGY_ID, raw_value=0.0, target_position=0.0)
 
     window = candles[-lookback_candles:]
     starting_price = window[0].close
     ending_price = window[-1].close
 
     if starting_price <= 0.0:
-        return SignalDecision(strategy="momentum", raw_value=0.0, target_position=0.0)
+        return SignalDecision(strategy=STRATEGY_ID, raw_value=0.0, target_position=0.0)
 
     raw_return = (ending_price / starting_price) - 1.0
     target_position = max(-1.0, min(1.0, raw_return * signal_scale))
     return SignalDecision(
-        strategy="momentum",
+        strategy=STRATEGY_ID,
         raw_value=raw_return,
         target_position=target_position,
     )

--- a/src/perpfut/strategy_registry.py
+++ b/src/perpfut/strategy_registry.py
@@ -1,0 +1,45 @@
+"""Registry-backed strategy dispatch."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+from .config import StrategyConfig
+from .domain import Candle, SignalDecision
+from .signal_momentum import STRATEGY_ID as MOMENTUM_STRATEGY_ID
+from .signal_momentum import compute_signal as compute_momentum_signal
+
+
+StrategyHandler = Callable[[Sequence[Candle], StrategyConfig], SignalDecision]
+
+
+def compute_strategy_signal(
+    candles: Sequence[Candle],
+    strategy: StrategyConfig,
+) -> SignalDecision:
+    validate_strategy_id(strategy.strategy_id)
+    handler = STRATEGY_REGISTRY[strategy.strategy_id]
+    return handler(candles, strategy)
+
+
+def validate_strategy_id(strategy_id: str) -> None:
+    try:
+        STRATEGY_REGISTRY[strategy_id]
+    except KeyError as exc:
+        available = ", ".join(sorted(STRATEGY_REGISTRY))
+        raise ValueError(
+            f"unknown strategy_id '{strategy_id}'; available strategies: {available}"
+        ) from exc
+
+
+def _compute_momentum(candles: Sequence[Candle], strategy: StrategyConfig) -> SignalDecision:
+    return compute_momentum_signal(
+        candles,
+        lookback_candles=strategy.lookback_candles,
+        signal_scale=strategy.signal_scale,
+    )
+
+
+STRATEGY_REGISTRY: dict[str, StrategyHandler] = {
+    MOMENTUM_STRATEGY_ID: _compute_momentum,
+}

--- a/src/perpfut/telemetry.py
+++ b/src/perpfut/telemetry.py
@@ -82,6 +82,7 @@ class ArtifactStore:
             "created_at": datetime.now(timezone.utc),
             "mode": config.runtime.mode,
             "product_id": config.runtime.product_id,
+            "strategy_id": config.strategy.strategy_id,
             "git_sha": _resolve_git_sha(),
             "resumed_from_run_id": self.resumed_from_run_id,
         }

--- a/tests/integration/test_api_paper_runs.py
+++ b/tests/integration/test_api_paper_runs.py
@@ -21,6 +21,7 @@ class StubManager:
             started_at="2026-03-22T00:00:00+00:00",
             run_id=None,
             product_id=request.product_id,
+            strategy_id=request.strategy_id,
             iterations=request.iterations,
             interval_seconds=request.interval_seconds,
             starting_collateral_usdc=request.starting_collateral_usdc,
@@ -41,6 +42,7 @@ def test_start_and_stop_paper_routes(monkeypatch) -> None:
         "/api/paper-runs",
         json={
             "productId": "BTC-PERP-INTX",
+            "strategyId": "momentum",
             "iterations": 12,
             "intervalSeconds": 60,
             "startingCollateralUsdc": 15000,
@@ -51,6 +53,7 @@ def test_start_and_stop_paper_routes(monkeypatch) -> None:
     assert start_response.status_code == 201
     assert start_response.json()["active"] is True
     assert start_response.json()["product_id"] == "BTC-PERP-INTX"
+    assert start_response.json()["strategy_id"] == "momentum"
     assert manager.started is not None
 
     assert stop_response.status_code == 200
@@ -67,6 +70,7 @@ def test_active_paper_route_returns_status(monkeypatch) -> None:
                 started_at="2026-03-22T00:00:00+00:00",
                 run_id="paper-123",
                 product_id="BTC-PERP-INTX",
+                strategy_id="momentum",
                 iterations=12,
                 interval_seconds=60,
                 starting_collateral_usdc=15000,
@@ -81,6 +85,7 @@ def test_active_paper_route_returns_status(monkeypatch) -> None:
     assert response.status_code == 200
     assert response.json()["active"] is True
     assert response.json()["run_id"] == "paper-123"
+    assert response.json()["strategy_id"] == "momentum"
 
 
 def test_start_paper_route_maps_conflict_to_409(monkeypatch) -> None:
@@ -95,6 +100,7 @@ def test_start_paper_route_maps_conflict_to_409(monkeypatch) -> None:
         "/api/paper-runs",
         json={
             "productId": "BTC-PERP-INTX",
+            "strategyId": "momentum",
             "iterations": 12,
             "intervalSeconds": 60,
             "startingCollateralUsdc": 15000,
@@ -117,6 +123,7 @@ def test_start_paper_route_maps_failures_to_500(monkeypatch) -> None:
         "/api/paper-runs",
         json={
             "productId": "BTC-PERP-INTX",
+            "strategyId": "momentum",
             "iterations": 12,
             "intervalSeconds": 60,
             "startingCollateralUsdc": 15000,
@@ -149,6 +156,7 @@ def test_start_paper_route_validates_payload(monkeypatch) -> None:
         "/api/paper-runs",
         json={
             "productId": "BTC-PERP-INTX",
+            "strategyId": "momentum",
             "iterations": 0,
             "intervalSeconds": 60,
             "startingCollateralUsdc": -1,

--- a/tests/integration/test_paper_engine.py
+++ b/tests/integration/test_paper_engine.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+import json
 
 from perpfut.config import AppConfig
 from perpfut.domain import Candle, MarketSnapshot
@@ -57,6 +58,8 @@ def test_paper_engine_runs_one_cycle_and_writes_artifacts(tmp_path) -> None:
     assert artifact_store.events_path.exists()
     assert artifact_store.positions_path.exists()
     assert artifact_store.state_path.exists()
+    manifest = json.loads(artifact_store.manifest_path.read_text(encoding="utf-8"))
+    assert manifest["strategy_id"] == "momentum"
 
 
 def test_paper_engine_records_skip_reason_when_delta_is_below_rebalance_threshold(

--- a/tests/unit/test_api_cli.py
+++ b/tests/unit/test_api_cli.py
@@ -38,6 +38,29 @@ def test_analyze_parser_defaults() -> None:
     assert args.mode == "paper"
 
 
+def test_paper_main_exits_cleanly_for_unknown_strategy(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("STRATEGY_ID", "unknown")
+
+    try:
+        main(
+            [
+                "paper",
+                "--runs-dir",
+                str(tmp_path),
+                "--iterations",
+                "1",
+                "--interval-seconds",
+                "0",
+            ]
+        )
+    except SystemExit as exc:
+        assert str(exc) == "unknown strategy_id 'unknown'; available strategies: momentum"
+    else:
+        raise AssertionError("expected SystemExit")
+
+    assert list(tmp_path.iterdir()) == []
+
+
 def test_analyze_main_prints_run_analysis(monkeypatch, tmp_path, capsys) -> None:
     run_id = "20260322T020000000000Z_beta"
     run_dir = tmp_path / run_id

--- a/tests/unit/test_paper_process_manager.py
+++ b/tests/unit/test_paper_process_manager.py
@@ -25,6 +25,7 @@ class DummyProcess:
 def _request() -> PaperRunRequest:
     return PaperRunRequest(
         productId="BTC-PERP-INTX",
+        strategyId="momentum",
         iterations=5,
         intervalSeconds=60,
         startingCollateralUsdc=10_000.0,
@@ -41,6 +42,7 @@ def _write_metadata(tmp_path, *, pid: int = 5678) -> None:
                 "started_at": "2026-03-22T00:00:00+00:00",
                 "run_id": None,
                 "product_id": "BTC-PERP-INTX",
+                "strategy_id": "momentum",
                 "iterations": 5,
                 "interval_seconds": 60,
                 "starting_collateral_usdc": 10000.0,
@@ -60,8 +62,10 @@ def test_start_persists_metadata_and_rejects_duplicate(monkeypatch, tmp_path) ->
     status = manager.start(_request())
 
     assert status.active is True
+    assert status.strategy_id == "momentum"
     payload = json.loads((tmp_path / "control" / "active_paper.json").read_text(encoding="utf-8"))
     assert payload["pid"] == 4321
+    assert payload["strategy_id"] == "momentum"
 
     with pytest.raises(PaperRunConflictError):
         manager.start(_request())
@@ -107,6 +111,30 @@ def test_start_raises_if_process_exits_immediately(monkeypatch, tmp_path) -> Non
 
     with pytest.raises(PaperRunStartError):
         manager.start(_request())
+
+
+def test_start_rejects_unknown_strategy_before_spawning(monkeypatch, tmp_path) -> None:
+    manager = PaperProcessManager(tmp_path)
+    started = {"called": False}
+
+    def fake_popen(*args, **kwargs):
+        started["called"] = True
+        return DummyProcess(7654)
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    with pytest.raises(PaperRunStartError, match="unknown strategy_id"):
+        manager.start(
+            PaperRunRequest(
+                productId="BTC-PERP-INTX",
+                strategyId="unknown",
+                iterations=5,
+                intervalSeconds=60,
+                startingCollateralUsdc=10_000.0,
+            )
+        )
+
+    assert started["called"] is False
 
 
 def test_status_raises_for_corrupted_metadata(monkeypatch, tmp_path) -> None:

--- a/tests/unit/test_strategy_registry.py
+++ b/tests/unit/test_strategy_registry.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from perpfut.config import StrategyConfig
+from perpfut.domain import Candle
+from perpfut.signal_momentum import compute_signal as compute_momentum_signal
+from perpfut.strategy_registry import compute_strategy_signal
+
+
+def _build_candles(count: int = 25) -> list[Candle]:
+    now = datetime.now(timezone.utc)
+    return [
+        Candle(
+            start=now + timedelta(minutes=index),
+            low=100.0 + index,
+            high=101.0 + index,
+            open=100.0 + index,
+            close=100.0 + index,
+            volume=1_000.0,
+        )
+        for index in range(count)
+    ]
+
+
+def test_registry_dispatch_preserves_momentum_behavior() -> None:
+    candles = _build_candles()
+    strategy = StrategyConfig(strategy_id="momentum", lookback_candles=20, signal_scale=35.0)
+
+    direct = compute_momentum_signal(candles, lookback_candles=20, signal_scale=35.0)
+    dispatched = compute_strategy_signal(candles, strategy)
+
+    assert dispatched == direct
+
+
+def test_registry_rejects_unknown_strategy() -> None:
+    candles = _build_candles()
+    strategy = StrategyConfig(strategy_id="unknown", lookback_candles=20, signal_scale=35.0)
+
+    with pytest.raises(ValueError, match="unknown strategy_id"):
+        compute_strategy_signal(candles, strategy)


### PR DESCRIPTION
Closes #39

## Summary
- add a registry-backed strategy dispatch layer and thread strategy identity through config
- move paper/live execution onto the registry while preserving momentum behavior
- persist `strategy_id` into run manifests and add coverage for the new dispatch path

## Testing
- python3 -m pytest
- python3 -m ruff check src/perpfut tests/unit/test_strategy_registry.py tests/integration/test_paper_engine.py