### PR TITLE
Add mean reversion strategy

### DIFF
--- a/apps/web/components/operator-shell.test.tsx
+++ b/apps/web/components/operator-shell.test.tsx
@@ -202,6 +202,7 @@ describe("OperatorShell", () => {
           started_at: null,
           run_id: null,
           product_id: null,
+          strategy_id: null,
           iterations: null,
           interval_seconds: null,
           starting_collateral_usdc: null,
@@ -216,6 +217,7 @@ describe("OperatorShell", () => {
       started_at: "2026-03-22T02:01:00Z",
       run_id: null,
       product_id: "BTC-PERP-INTX",
+      strategy_id: "mean_reversion",
       iterations: 1440,
       interval_seconds: 60,
       starting_collateral_usdc: 10000,
@@ -231,11 +233,13 @@ describe("OperatorShell", () => {
     expect(screen.getByText("Latest Cycle Decision")).toBeInTheDocument();
     expect(screen.getByText("Filled a rebalance order toward the target position.")).toBeInTheDocument();
 
+    await userEvent.selectOptions(screen.getByLabelText("Strategy"), "mean_reversion");
     await userEvent.click(screen.getByRole("button", { name: "Start Paper Run" }));
 
     await waitFor(() =>
       expect(mockedStartPaperRun).toHaveBeenCalledWith({
         productId: "BTC-PERP-INTX",
+        strategyId: "mean_reversion",
         iterations: 1440,
         intervalSeconds: 60,
         startingCollateralUsdc: 10000,
@@ -243,6 +247,7 @@ describe("OperatorShell", () => {
     );
     expect(await screen.findByText("Paper run started for BTC-PERP-INTX.")).toBeInTheDocument();
     expect(screen.getByText("PID 4321")).toBeInTheDocument();
+    expect(screen.getByText("mean_reversion")).toBeInTheDocument();
   });
 
   it("stops an active paper run", async () => {
@@ -260,6 +265,7 @@ describe("OperatorShell", () => {
           started_at: "2026-03-22T02:01:00Z",
           run_id: null,
           product_id: "BTC-PERP-INTX",
+          strategy_id: "momentum",
           iterations: 1440,
           interval_seconds: 60,
           starting_collateral_usdc: 10000,
@@ -274,6 +280,7 @@ describe("OperatorShell", () => {
       started_at: null,
       run_id: null,
       product_id: "BTC-PERP-INTX",
+      strategy_id: "momentum",
       iterations: 1440,
       interval_seconds: 60,
       starting_collateral_usdc: 10000,
@@ -304,6 +311,7 @@ describe("OperatorShell", () => {
           started_at: null,
           run_id: null,
           product_id: null,
+          strategy_id: null,
           iterations: null,
           interval_seconds: null,
           starting_collateral_usdc: null,
@@ -342,6 +350,7 @@ describe("OperatorShell", () => {
           started_at: null,
           run_id: null,
           product_id: null,
+          strategy_id: null,
           iterations: null,
           interval_seconds: null,
           starting_collateral_usdc: null,
@@ -377,6 +386,7 @@ describe("OperatorShell", () => {
           started_at: null,
           run_id: null,
           product_id: null,
+          strategy_id: null,
           iterations: null,
           interval_seconds: null,
           starting_collateral_usdc: null,
@@ -422,6 +432,7 @@ describe("OperatorShell", () => {
           started_at: null,
           run_id: null,
           product_id: null,
+          strategy_id: null,
           iterations: null,
           interval_seconds: null,
           starting_collateral_usdc: null,

--- a/apps/web/components/operator-shell.tsx
+++ b/apps/web/components/operator-shell.tsx
@@ -37,6 +37,7 @@ import {
 
 const DEFAULT_PAPER_FORM = {
   productId: "BTC-PERP-INTX",
+  strategyId: "momentum",
   iterations: "1440",
   intervalSeconds: "60",
   startingCollateralUsdc: "10000",
@@ -329,6 +330,41 @@ function ControlField({
   );
 }
 
+function ControlSelect({
+  label,
+  name,
+  value,
+  onChange,
+  disabled,
+  options,
+}: {
+  label: string;
+  name: string;
+  value: string;
+  onChange: (name: string, value: string) => void;
+  disabled: boolean;
+  options: Array<{ value: string; label: string }>;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-2 block text-[11px] uppercase tracking-[0.22em] text-[var(--muted)]">{label}</span>
+      <select
+        aria-label={label}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(name, event.target.value)}
+        className="mono w-full border border-[var(--border)] bg-[var(--bg-elevated)] px-3 py-3 text-sm text-[var(--text)] outline-none transition focus:border-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
 function PaperControlPanel({
   activeRun,
   latestRunId,
@@ -373,6 +409,17 @@ function PaperControlPanel({
               value={form.productId}
               onChange={onFieldChange}
               disabled={isActive || pendingAction !== null}
+            />
+            <ControlSelect
+              label="Strategy"
+              name="strategyId"
+              value={form.strategyId}
+              onChange={onFieldChange}
+              disabled={isActive || pendingAction !== null}
+              options={[
+                { value: "momentum", label: "Momentum" },
+                { value: "mean_reversion", label: "Mean Reversion" },
+              ]}
             />
             <ControlField
               label="Iterations"
@@ -444,6 +491,10 @@ function PaperControlPanel({
               <dd className="mono text-[var(--text)]">{activeRun?.product_id ?? form.productId}</dd>
             </div>
             <div className="flex items-center justify-between gap-4">
+              <dt className="text-[var(--muted)]">Strategy</dt>
+              <dd className="mono text-[var(--text)]">{activeRun?.strategy_id ?? form.strategyId}</dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
               <dt className="text-[var(--muted)]">Started</dt>
               <dd className="text-[var(--text)]">{formatTimestamp(activeRun?.started_at ?? null)}</dd>
             </div>
@@ -475,12 +526,16 @@ function parsePaperRunRequest(form: typeof DEFAULT_PAPER_FORM): {
   error: string | null;
 } {
   const productId = form.productId.trim();
+  const strategyId = form.strategyId.trim();
   const iterations = Number.parseInt(form.iterations, 10);
   const intervalSeconds = Number.parseInt(form.intervalSeconds, 10);
   const startingCollateralUsdc = Number.parseFloat(form.startingCollateralUsdc);
 
   if (!productId) {
     return { request: null, error: "Product ID is required." };
+  }
+  if (!strategyId) {
+    return { request: null, error: "Strategy is required." };
   }
   if (!Number.isInteger(iterations) || iterations <= 0) {
     return { request: null, error: "Iterations must be a positive integer." };
@@ -495,6 +550,7 @@ function parsePaperRunRequest(form: typeof DEFAULT_PAPER_FORM): {
   return {
     request: {
       productId,
+      strategyId,
       iterations,
       intervalSeconds,
       startingCollateralUsdc,

--- a/src/perpfut/signal_mean_reversion.py
+++ b/src/perpfut/signal_mean_reversion.py
@@ -1,0 +1,34 @@
+"""Pure signal logic for a baseline mean-reversion strategy."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from .domain import Candle, SignalDecision
+
+STRATEGY_ID = "mean_reversion"
+
+
+def compute_signal(
+    candles: Sequence[Candle],
+    *,
+    lookback_candles: int,
+    signal_scale: float,
+) -> SignalDecision:
+    if len(candles) < lookback_candles:
+        return SignalDecision(strategy=STRATEGY_ID, raw_value=0.0, target_position=0.0)
+
+    window = candles[-lookback_candles:]
+    starting_price = window[0].close
+    ending_price = window[-1].close
+
+    if starting_price <= 0.0:
+        return SignalDecision(strategy=STRATEGY_ID, raw_value=0.0, target_position=0.0)
+
+    raw_return = (ending_price / starting_price) - 1.0
+    target_position = max(-1.0, min(1.0, -(raw_return * signal_scale)))
+    return SignalDecision(
+        strategy=STRATEGY_ID,
+        raw_value=raw_return,
+        target_position=target_position,
+    )

--- a/src/perpfut/strategy_registry.py
+++ b/src/perpfut/strategy_registry.py
@@ -6,6 +6,8 @@ from collections.abc import Callable, Sequence
 
 from .config import StrategyConfig
 from .domain import Candle, SignalDecision
+from .signal_mean_reversion import STRATEGY_ID as MEAN_REVERSION_STRATEGY_ID
+from .signal_mean_reversion import compute_signal as compute_mean_reversion_signal
 from .signal_momentum import STRATEGY_ID as MOMENTUM_STRATEGY_ID
 from .signal_momentum import compute_signal as compute_momentum_signal
 
@@ -40,6 +42,18 @@ def _compute_momentum(candles: Sequence[Candle], strategy: StrategyConfig) -> Si
     )
 
 
+def _compute_mean_reversion(
+    candles: Sequence[Candle],
+    strategy: StrategyConfig,
+) -> SignalDecision:
+    return compute_mean_reversion_signal(
+        candles,
+        lookback_candles=strategy.lookback_candles,
+        signal_scale=strategy.signal_scale,
+    )
+
+
 STRATEGY_REGISTRY: dict[str, StrategyHandler] = {
     MOMENTUM_STRATEGY_ID: _compute_momentum,
+    MEAN_REVERSION_STRATEGY_ID: _compute_mean_reversion,
 }

--- a/tests/integration/test_api_paper_runs.py
+++ b/tests/integration/test_api_paper_runs.py
@@ -42,7 +42,7 @@ def test_start_and_stop_paper_routes(monkeypatch) -> None:
         "/api/paper-runs",
         json={
             "productId": "BTC-PERP-INTX",
-            "strategyId": "momentum",
+            "strategyId": "mean_reversion",
             "iterations": 12,
             "intervalSeconds": 60,
             "startingCollateralUsdc": 15000,
@@ -53,8 +53,9 @@ def test_start_and_stop_paper_routes(monkeypatch) -> None:
     assert start_response.status_code == 201
     assert start_response.json()["active"] is True
     assert start_response.json()["product_id"] == "BTC-PERP-INTX"
-    assert start_response.json()["strategy_id"] == "momentum"
+    assert start_response.json()["strategy_id"] == "mean_reversion"
     assert manager.started is not None
+    assert manager.started.strategy_id == "mean_reversion"
 
     assert stop_response.status_code == 200
     assert stop_response.json()["active"] is False

--- a/tests/unit/test_api_cli.py
+++ b/tests/unit/test_api_cli.py
@@ -54,7 +54,7 @@ def test_paper_main_exits_cleanly_for_unknown_strategy(monkeypatch, tmp_path) ->
             ]
         )
     except SystemExit as exc:
-        assert str(exc) == "unknown strategy_id 'unknown'; available strategies: momentum"
+        assert str(exc) == "unknown strategy_id 'unknown'; available strategies: mean_reversion, momentum"
     else:
         raise AssertionError("expected SystemExit")
 

--- a/tests/unit/test_paper_process_manager.py
+++ b/tests/unit/test_paper_process_manager.py
@@ -55,7 +55,13 @@ def _write_metadata(tmp_path, *, pid: int = 5678) -> None:
 
 def test_start_persists_metadata_and_rejects_duplicate(monkeypatch, tmp_path) -> None:
     manager = PaperProcessManager(tmp_path)
-    monkeypatch.setattr("subprocess.Popen", lambda *args, **kwargs: DummyProcess(4321))
+    captured = {}
+
+    def fake_popen(*args, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        return DummyProcess(4321)
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
     monkeypatch.setattr("time.sleep", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(manager, "_is_process_alive", lambda pid: pid == 4321)
 
@@ -66,6 +72,7 @@ def test_start_persists_metadata_and_rejects_duplicate(monkeypatch, tmp_path) ->
     payload = json.loads((tmp_path / "control" / "active_paper.json").read_text(encoding="utf-8"))
     assert payload["pid"] == 4321
     assert payload["strategy_id"] == "momentum"
+    assert captured["env"]["STRATEGY_ID"] == "momentum"
 
     with pytest.raises(PaperRunConflictError):
         manager.start(_request())

--- a/tests/unit/test_signal_mean_reversion.py
+++ b/tests/unit/test_signal_mean_reversion.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timedelta, timezone
+
+from perpfut.domain import Candle
+from perpfut.signal_mean_reversion import compute_signal
+
+
+def test_mean_reversion_returns_negative_target_for_uptrend() -> None:
+    now = datetime.now(timezone.utc)
+    candles = [
+        Candle(
+            start=now + timedelta(minutes=index),
+            low=100.0 + index,
+            high=101.0 + index,
+            open=100.0 + index,
+            close=100.0 + index,
+            volume=1_000.0,
+        )
+        for index in range(25)
+    ]
+
+    signal = compute_signal(candles, lookback_candles=20, signal_scale=35.0)
+
+    assert signal.strategy == "mean_reversion"
+    assert signal.raw_value > 0.0
+    assert signal.target_position < 0.0
+
+
+def test_mean_reversion_returns_positive_target_for_downtrend() -> None:
+    now = datetime.now(timezone.utc)
+    candles = [
+        Candle(
+            start=now + timedelta(minutes=index),
+            low=100.0 - index,
+            high=101.0 - index,
+            open=100.0 - index,
+            close=100.0 - index,
+            volume=1_000.0,
+        )
+        for index in range(25)
+    ]
+
+    signal = compute_signal(candles, lookback_candles=20, signal_scale=35.0)
+
+    assert signal.raw_value < 0.0
+    assert signal.target_position > 0.0
+
+
+def test_mean_reversion_clips_large_move() -> None:
+    now = datetime.now(timezone.utc)
+    candles = [
+        Candle(
+            start=now + timedelta(minutes=index),
+            low=100.0,
+            high=400.0,
+            open=100.0,
+            close=400.0 if index == 24 else 100.0,
+            volume=1_000.0,
+        )
+        for index in range(25)
+    ]
+
+    signal = compute_signal(candles, lookback_candles=20, signal_scale=35.0)
+
+    assert signal.target_position == -1.0
+
+
+def test_mean_reversion_returns_zero_when_prices_are_invalid() -> None:
+    now = datetime.now(timezone.utc)
+    candles = [
+        Candle(
+            start=now + timedelta(minutes=index),
+            low=0.0,
+            high=0.0,
+            open=0.0,
+            close=0.0,
+            volume=1_000.0,
+        )
+        for index in range(25)
+    ]
+
+    signal = compute_signal(candles, lookback_candles=20, signal_scale=35.0)
+
+    assert signal.raw_value == 0.0
+    assert signal.target_position == 0.0

--- a/tests/unit/test_strategy_registry.py
+++ b/tests/unit/test_strategy_registry.py
@@ -4,6 +4,7 @@ import pytest
 
 from perpfut.config import StrategyConfig
 from perpfut.domain import Candle
+from perpfut.signal_mean_reversion import compute_signal as compute_mean_reversion_signal
 from perpfut.signal_momentum import compute_signal as compute_momentum_signal
 from perpfut.strategy_registry import compute_strategy_signal
 
@@ -39,3 +40,13 @@ def test_registry_rejects_unknown_strategy() -> None:
 
     with pytest.raises(ValueError, match="unknown strategy_id"):
         compute_strategy_signal(candles, strategy)
+
+
+def test_registry_dispatches_mean_reversion() -> None:
+    candles = _build_candles()
+    strategy = StrategyConfig(strategy_id="mean_reversion", lookback_candles=20, signal_scale=35.0)
+
+    direct = compute_mean_reversion_signal(candles, lookback_candles=20, signal_scale=35.0)
+    dispatched = compute_strategy_signal(candles, strategy)
+
+    assert dispatched == direct


### PR DESCRIPTION
Closes #40

## Summary
- add a pure mean-reversion baseline strategy alongside momentum
- register mean reversion in the strategy registry for selection via `strategy_id`
- add direct contract tests for normalization, scaling, clipping, and selection

## Testing
- python3 -m pytest
- python3 -m ruff check src/perpfut tests/unit/test_signal_mean_reversion.py tests/unit/test_strategy_registry.py tests/unit/test_api_cli.py