### PR TITLE
BT-1: extract reusable snapshot runner

### DIFF
--- a/src/perpfut/engine.py
+++ b/src/perpfut/engine.py
@@ -33,37 +33,25 @@ class MarketDataClient(Protocol):
         ...
 
 
-class PaperEngine:
-    """Coordinates the paper-trading loop."""
+class SnapshotCycleRunner:
+    """Executes trading cycles from supplied market snapshots."""
 
     def __init__(
         self,
         *,
         config: AppConfig,
-        market_data: MarketDataClient,
         artifact_store: ArtifactStore,
+        mode: Mode = Mode.PAPER,
+        initial_state: PositionState | None = None,
     ):
         self.config = config
-        self.market_data = market_data
         self.artifact_store = artifact_store
-        self.state = PositionState(
+        self.mode = mode
+        self.state = initial_state or PositionState(
             collateral_usdc=config.simulation.starting_collateral_usdc,
         )
 
-    def run(self) -> list[CycleResult]:
-        results = []
-        for cycle_number in range(1, self.config.runtime.iterations + 1):
-            result = self.run_cycle(cycle_number)
-            results.append(result)
-            if cycle_number < self.config.runtime.iterations:
-                time.sleep(self.config.runtime.interval_seconds)
-        return results
-
-    def run_cycle(self, cycle_number: int) -> CycleResult:
-        market = self.market_data.fetch_market(
-            self.config.runtime.product_id,
-            candle_limit=self.config.strategy.lookback_candles,
-        )
+    def run_cycle(self, cycle_number: int, market: MarketSnapshot) -> CycleResult:
         marked_state = replace(self.state, mark_price=market.mid_price)
         signal = compute_strategy_signal(
             market.candles,
@@ -139,7 +127,7 @@ class PaperEngine:
 
         cycle_result = CycleResult(
             cycle_id=f"cycle-{cycle_number:04d}",
-            mode=Mode.PAPER,
+            mode=self.mode,
             market=market,
             signal=replace(signal, target_position=target_position),
             risk_decision=risk_decision,
@@ -152,6 +140,48 @@ class PaperEngine:
         self.state = marked_state
         self.artifact_store.record_cycle(cycle_result)
         return cycle_result
+
+
+class PaperEngine:
+    """Coordinates the paper-trading loop."""
+
+    def __init__(
+        self,
+        *,
+        config: AppConfig,
+        market_data: MarketDataClient,
+        artifact_store: ArtifactStore,
+    ):
+        self.config = config
+        self.market_data = market_data
+        self.runner = SnapshotCycleRunner(
+            config=config,
+            artifact_store=artifact_store,
+            mode=Mode.PAPER,
+        )
+
+    def run(self) -> list[CycleResult]:
+        results = []
+        for cycle_number in range(1, self.config.runtime.iterations + 1):
+            result = self.run_cycle(cycle_number)
+            results.append(result)
+            if cycle_number < self.config.runtime.iterations:
+                time.sleep(self.config.runtime.interval_seconds)
+        return results
+
+    def run_cycle(self, cycle_number: int) -> CycleResult:
+        market = self.market_data.fetch_market(
+            self.config.runtime.product_id,
+            candle_limit=self.config.strategy.lookback_candles,
+        )
+        return self.run_market_cycle(cycle_number, market)
+
+    def run_market_cycle(self, cycle_number: int, market: MarketSnapshot) -> CycleResult:
+        return self.runner.run_cycle(cycle_number, market)
+
+    @property
+    def state(self) -> PositionState:
+        return self.runner.state
 
 
 def build_order_plan(

--- a/tests/integration/test_paper_engine.py
+++ b/tests/integration/test_paper_engine.py
@@ -31,6 +31,33 @@ class FakeMarketData:
         )
 
 
+class FailingMarketData:
+    def fetch_market(self, product_id: str, *, candle_limit: int) -> MarketSnapshot:
+        raise AssertionError("market fetch should not be called")
+
+
+def build_snapshot(*, product_id: str, anchor: datetime) -> MarketSnapshot:
+    candles = tuple(
+        Candle(
+            start=anchor + timedelta(minutes=index),
+            low=100.0 + index,
+            high=101.0 + index,
+            open=100.0 + index,
+            close=100.0 + index,
+            volume=1_000.0,
+        )
+        for index in range(30)
+    )
+    return MarketSnapshot(
+        product_id=product_id,
+        as_of=anchor,
+        last_price=candles[-1].close,
+        best_bid=candles[-1].close - 0.5,
+        best_ask=candles[-1].close + 0.5,
+        candles=candles,
+    )
+
+
 def test_paper_engine_runs_one_cycle_and_writes_artifacts(tmp_path) -> None:
     config = AppConfig.from_env().with_overrides(
         product_id="BTC-PERP-INTX",
@@ -116,3 +143,34 @@ def test_paper_engine_records_skip_reason_when_delta_is_below_min_trade_notional
     assert result.no_trade_reason is not None
     assert result.no_trade_reason.code == "below_min_trade_notional"
     assert result.execution_summary.reason_code == "below_min_trade_notional"
+
+
+def test_paper_engine_can_run_a_cycle_from_a_supplied_market_snapshot(tmp_path) -> None:
+    config = AppConfig.from_env().with_overrides(
+        product_id="BTC-PERP-INTX",
+        iterations=1,
+        interval_seconds=0,
+        runs_dir=tmp_path,
+    )
+    artifact_store = ArtifactStore.create(config.runtime.runs_dir)
+    artifact_store.write_metadata(config)
+    engine = PaperEngine(
+        config=config,
+        market_data=FailingMarketData(),
+        artifact_store=artifact_store,
+    )
+
+    snapshot = build_snapshot(
+        product_id="BTC-PERP-INTX",
+        anchor=datetime(2026, 3, 22, 5, 0, tzinfo=timezone.utc),
+    )
+
+    result = engine.run_market_cycle(1, snapshot)
+
+    assert result.market == snapshot
+    assert result.order_intent is not None
+    assert result.fill is not None
+    assert result.state.quantity > 0.0
+    state_payload = json.loads(artifact_store.state_path.read_text(encoding="utf-8"))
+    assert state_payload["product_id"] == "BTC-PERP-INTX"
+    assert state_payload["fill"]["price"] == result.fill.price


### PR DESCRIPTION
Closes #57\n\n## Summary\n- extract a snapshot-driven runner from the paper engine\n- preserve existing paper-mode behavior through the paper engine wrapper\n- add regression coverage for executing a cycle from a supplied market snapshot\n\n## Testing\n- python3 -m pytest tests/integration/test_paper_engine.py tests/integration/test_mvp_smoke.py tests/unit/test_api_cli.py tests/unit/test_strategy_registry.py\n- python3 -m ruff check src/perpfut/engine.py tests/integration/test_paper_engine.py