### PR TITLE
BT-8: add permanent backtests navigation shell

### DIFF
--- a/apps/web/app/backtests/[runId]/page.tsx
+++ b/apps/web/app/backtests/[runId]/page.tsx
@@ -1,0 +1,11 @@
+import { BacktestRunShell } from "@/components/backtest-run-shell";
+
+
+export default async function BacktestRunPage({
+  params,
+}: {
+  params: Promise<{ runId: string }>;
+}) {
+  const { runId } = await params;
+  return <BacktestRunShell runId={runId} />;
+}

--- a/apps/web/app/backtests/page.tsx
+++ b/apps/web/app/backtests/page.tsx
@@ -1,0 +1,6 @@
+import { BacktestsShell } from "@/components/backtests-shell";
+
+
+export default function BacktestsPage() {
+  return <BacktestsShell />;
+}

--- a/apps/web/components/backtest-run-shell.tsx
+++ b/apps/web/components/backtest-run-shell.tsx
@@ -1,0 +1,114 @@
+import Link from "next/link";
+
+import { ConsoleNav } from "@/components/console-nav";
+
+
+function ShellPanel({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <section className={`panel ${className}`}>{children}</section>;
+}
+
+function ShellHeader({
+  eyebrow,
+  title,
+  action,
+}: {
+  eyebrow: string;
+  title: string;
+  action?: string;
+}) {
+  return (
+    <div className="mb-4 flex items-end justify-between gap-4">
+      <div>
+        <div className="mono text-[10px] uppercase tracking-[0.34em] text-[var(--accent)]">{eyebrow}</div>
+        <h2 className="mt-2 text-lg font-semibold tracking-tight text-[var(--text)]">{title}</h2>
+      </div>
+      {action ? <div className="text-xs text-[var(--muted)]">{action}</div> : null}
+    </div>
+  );
+}
+
+export function BacktestRunShell({ runId }: { runId: string }) {
+  return (
+    <main className="min-h-screen px-4 py-4 text-[var(--text)] sm:px-6 lg:px-8">
+      <div className="mx-auto grid max-w-[1680px] gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
+        <aside className="panel flex min-h-[calc(100vh-2rem)] flex-col justify-between p-5">
+          <div>
+            <div className="mono text-[11px] uppercase tracking-[0.34em] text-[var(--accent)]">perpfut</div>
+            <div className="mt-3 text-2xl font-semibold tracking-tight">Backtest Detail</div>
+            <p className="mt-3 max-w-xs text-sm leading-6 text-[var(--muted)]">
+              Drill into a single backtest run with the same operator styling used across the console.
+            </p>
+            <ConsoleNav active="backtests" />
+          </div>
+
+          <div className="space-y-4">
+            <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+              <div className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--warning)]">
+                Selected Run
+              </div>
+              <div className="mt-3 text-sm text-[var(--text)]">{runId}</div>
+              <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+                This permanent route shell is in place. The full analysis, fill tape, and decision drill-down
+                wiring land in the next run-detail PR.
+              </p>
+            </div>
+          </div>
+        </aside>
+
+        <section className="space-y-4">
+          <header className="panel panel-strong flex flex-col gap-5 p-5 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <div className="mono text-[11px] uppercase tracking-[0.34em] text-[var(--accent)]">
+                Backtest Run
+              </div>
+              <h1 className="mt-3 max-w-3xl text-3xl font-semibold tracking-tight">
+                Run Detail: {runId}
+              </h1>
+              <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--muted)]">
+                This route will render canonical analysis, decisions, fills, and per-asset portfolio views
+                from the backtest API. The shell exists now so the navigation and URL model are stable.
+              </p>
+            </div>
+            <Link
+              href="/backtests"
+              className="inline-flex items-center border border-[var(--border)] px-4 py-3 text-xs uppercase tracking-[0.24em] text-[var(--muted)] transition hover:border-[var(--border-strong)] hover:text-[var(--text)]"
+            >
+              Back to Backtests
+            </Link>
+          </header>
+
+          <div className="grid gap-4 lg:grid-cols-3">
+            <ShellPanel className="p-5">
+              <ShellHeader eyebrow="Analysis" title="Canonical metrics panel" action="BT-10" />
+              <div className="min-h-48 border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+                Equity, drawdown, turnover, and exposure summaries will render here from the canonical
+                analysis contract.
+              </div>
+            </ShellPanel>
+
+            <ShellPanel className="p-5">
+              <ShellHeader eyebrow="Decisions" title="Decision drill-down" action="BT-10" />
+              <div className="min-h-48 border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+                Cycle-level explanations and no-trade reasons for the selected backtest run land in the next
+                frontend step.
+              </div>
+            </ShellPanel>
+
+            <ShellPanel className="p-5">
+              <ShellHeader eyebrow="Assets" title="Per-asset inspection" action="BT-10" />
+              <div className="min-h-48 border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+                Per-asset positions, fills, and contribution views are reserved for the full detail page.
+              </div>
+            </ShellPanel>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/backtests-shell.test.tsx
+++ b/apps/web/components/backtests-shell.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BacktestRunShell } from "@/components/backtest-run-shell";
+import { BacktestsShell } from "@/components/backtests-shell";
+
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+describe("Backtest shells", () => {
+  it("renders the backtests overview shell with permanent navigation", () => {
+    render(<BacktestsShell />);
+
+    expect(screen.getByText("Backtest Console")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Overview/i })).toHaveAttribute("href", "/");
+    expect(
+      screen
+        .getAllByRole("link", { name: /Backtests/i })
+        .some((element) => element.getAttribute("href") === "/backtests")
+    ).toBe(true);
+    expect(screen.getByText("Launch, rank, inspect")).toBeInTheDocument();
+  });
+
+  it("renders the backtest run detail shell with a stable route model", () => {
+    render(<BacktestRunShell runId="suite-run-1" />);
+
+    expect(screen.getByText("Run Detail: suite-run-1")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Back to Backtests/i })).toHaveAttribute("href", "/backtests");
+    expect(screen.getByText("Per-asset inspection")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/backtests-shell.tsx
+++ b/apps/web/components/backtests-shell.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+
+import { ConsoleNav } from "@/components/console-nav";
+
+
+function ShellPanel({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <section className={`panel ${className}`}>{children}</section>;
+}
+
+function ShellHeader({
+  eyebrow,
+  title,
+  action,
+}: {
+  eyebrow: string;
+  title: string;
+  action?: string;
+}) {
+  return (
+    <div className="mb-4 flex items-end justify-between gap-4">
+      <div>
+        <div className="mono text-[10px] uppercase tracking-[0.34em] text-[var(--accent)]">{eyebrow}</div>
+        <h2 className="mt-2 text-lg font-semibold tracking-tight text-[var(--text)]">{title}</h2>
+      </div>
+      {action ? <div className="text-xs text-[var(--muted)]">{action}</div> : null}
+    </div>
+  );
+}
+
+export function BacktestsShell() {
+  return (
+    <main className="min-h-screen px-4 py-4 text-[var(--text)] sm:px-6 lg:px-8">
+      <div className="mx-auto grid max-w-[1680px] gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
+        <aside className="panel flex min-h-[calc(100vh-2rem)] flex-col justify-between p-5">
+          <div>
+            <div className="mono text-[11px] uppercase tracking-[0.34em] text-[var(--accent)]">perpfut</div>
+            <div className="mt-3 text-2xl font-semibold tracking-tight">Backtest Console</div>
+            <p className="mt-3 max-w-xs text-sm leading-6 text-[var(--muted)]">
+              Historical strategy evaluation with shared production strategy code, artifact-backed datasets,
+              and suite comparisons.
+            </p>
+            <ConsoleNav active="backtests" />
+          </div>
+
+          <div className="space-y-4">
+            <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+              <div className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--warning)]">
+                Runtime Contract
+              </div>
+              <div className="mt-3 text-sm text-[var(--text)]">Bar-close signals, next-open fills</div>
+              <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+                Backtests reuse the same strategy registry as paper and live execution. Multi-asset allocation
+                exists only inside the backtest runner.
+              </p>
+            </div>
+
+            <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+              <div className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--warning)]">
+                Console Scope
+              </div>
+              <div className="mt-3 text-sm text-[var(--text)]">Launch, rank, inspect</div>
+              <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+                This shell is permanent navigation scaffolding. The launch form, suite leaderboard, and run
+                detail data wiring land in the next backtest frontend PRs.
+              </p>
+            </div>
+          </div>
+        </aside>
+
+        <section className="space-y-4">
+          <header className="panel panel-strong flex flex-col gap-5 p-5 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <div className="mono text-[11px] uppercase tracking-[0.34em] text-[var(--accent)]">
+                Historical Console
+              </div>
+              <h1 className="mt-3 max-w-3xl text-3xl font-semibold tracking-tight">
+                Historical backtests with reusable production strategy code.
+              </h1>
+              <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--muted)]">
+                Use this area to launch multi-asset backtest suites, compare strategy candidates on the
+                canonical metrics contract, and drill into portfolio decisions without leaving the operator UI.
+              </p>
+            </div>
+            <div className="grid gap-2 text-xs uppercase tracking-[0.22em] text-[var(--muted)] sm:grid-cols-3">
+              <div className="border border-[var(--border)] px-3 py-3">
+                <div className="mono text-[10px] text-[var(--accent)]">Source</div>
+                <div className="mt-2 text-sm text-[var(--text)]">Coinbase Candles</div>
+              </div>
+              <div className="border border-[var(--border)] px-3 py-3">
+                <div className="mono text-[10px] text-[var(--accent)]">Execution</div>
+                <div className="mt-2 text-sm text-[var(--text)]">Next Open</div>
+              </div>
+              <div className="border border-[var(--border)] px-3 py-3">
+                <div className="mono text-[10px] text-[var(--accent)]">Artifacts</div>
+                <div className="mt-2 text-sm text-[var(--text)]">runs/backtests</div>
+              </div>
+            </div>
+          </header>
+
+          <div className="grid gap-4 xl:grid-cols-[1.3fr_0.9fr]">
+            <ShellPanel className="p-5">
+              <ShellHeader eyebrow="Launch Surface" title="Backtest suite controls arrive next" action="BT-9" />
+              <div className="signal-grid grid min-h-80 place-items-center border border-[var(--border)] bg-[var(--bg-elevated)] p-8 text-center">
+                <div>
+                  <div className="text-base font-medium text-[var(--text)]">Launch, list, and compare live here next.</div>
+                  <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--muted)]">
+                    The next frontend step wires the launch form to <span className="mono">POST /api/backtests</span> and
+                    renders suite rankings from <span className="mono">/api/backtest-suites</span>.
+                  </p>
+                </div>
+              </div>
+            </ShellPanel>
+
+            <ShellPanel className="p-5">
+              <ShellHeader eyebrow="Routes" title="Backtest drill-down is now addressable" />
+              <div className="space-y-3 text-sm leading-6 text-[var(--muted)]">
+                <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+                  Overview route: <Link href="/backtests" className="text-[var(--accent)] underline decoration-[var(--border)] underline-offset-4">/backtests</Link>
+                </div>
+                <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+                  Run detail route: <Link href="/backtests/demo-run" className="text-[var(--accent)] underline decoration-[var(--border)] underline-offset-4">/backtests/[runId]</Link>
+                </div>
+                <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+                  Existing live operator dashboard remains at <Link href="/" className="text-[var(--accent)] underline decoration-[var(--border)] underline-offset-4">/</Link>.
+                </div>
+              </div>
+            </ShellPanel>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/components/console-nav.tsx
+++ b/apps/web/components/console-nav.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+
+
+type ConsoleNavKey = "overview" | "backtests";
+
+const NAV_ITEMS: Array<{ key: ConsoleNavKey; label: string; href: string }> = [
+  { key: "overview", label: "Overview", href: "/" },
+  { key: "backtests", label: "Backtests", href: "/backtests" },
+];
+
+export function ConsoleNav({ active }: { active: ConsoleNavKey }) {
+  return (
+    <div className="mt-8 space-y-2">
+      {NAV_ITEMS.map((item, index) => (
+        <Link
+          key={item.key}
+          href={item.href}
+          className={`flex items-center justify-between border px-3 py-3 text-sm tracking-wide transition ${
+            item.key === active
+              ? "border-[var(--border-strong)] bg-[rgba(84,191,255,0.08)]"
+              : "border-transparent bg-transparent text-[var(--muted)] hover:border-[var(--border)] hover:text-[var(--text)]"
+          }`}
+        >
+          <span>{item.label}</span>
+          <span className="mono text-[11px]">{String(index + 1).padStart(2, "0")}</span>
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/operator-shell.test.tsx
+++ b/apps/web/components/operator-shell.test.tsx
@@ -229,6 +229,7 @@ describe("OperatorShell", () => {
     expect(await screen.findByText("Start or stop the local paper process")).toBeInTheDocument();
     expect(await screen.findByText("+1.25%")).toBeInTheDocument();
     expect(screen.queryByText("Canonical analysis unavailable")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Backtests/i })).toHaveAttribute("href", "/backtests");
     expect(screen.getByText("Equity Curve")).toBeInTheDocument();
     expect(screen.getByText("Latest Cycle Decision")).toBeInTheDocument();
     expect(screen.getByText("Filled a rebalance order toward the target position.")).toBeInTheDocument();

--- a/apps/web/components/operator-shell.tsx
+++ b/apps/web/components/operator-shell.tsx
@@ -33,6 +33,7 @@ import {
   type PaperRunStatusResponse,
   type RunsListResponse,
 } from "@/lib/perpfut-api";
+import { ConsoleNav } from "@/components/console-nav";
 
 
 const DEFAULT_PAPER_FORM = {
@@ -681,22 +682,7 @@ export function OperatorShell() {
             <p className="mt-3 max-w-xs text-sm leading-6 text-[var(--muted)]">
               Local-first monitoring for paper execution, artifact inspection, and operator control.
             </p>
-            <div className="mt-8 space-y-2">
-              {["Overview", "Runs", "Paper Control", "Live Readiness"].map((item, index) => (
-                <Link
-                  key={item}
-                  href={index === 0 ? "/" : "#"}
-                  className={`flex items-center justify-between border px-3 py-3 text-sm tracking-wide transition ${
-                    index === 0
-                      ? "border-[var(--border-strong)] bg-[rgba(84,191,255,0.08)]"
-                      : "border-transparent bg-transparent text-[var(--muted)] hover:border-[var(--border)] hover:text-[var(--text)]"
-                  }`}
-                >
-                  <span>{item}</span>
-                  <span className="mono text-[11px]">{String(index + 1).padStart(2, "0")}</span>
-                </Link>
-              ))}
-            </div>
+            <ConsoleNav active="overview" />
           </div>
 
           <div className="space-y-4">


### PR DESCRIPTION
Closes #64\n\n## Summary\n- add permanent Backtests navigation to the operator UI\n- add /backtests and /backtests/[runId] route shells in the existing dark operator style\n- add frontend coverage for the new navigation and shell routes