### PR TITLE
[BT-10] Build backtest detail page

### DIFF
--- a/apps/web/components/backtest-run-shell.tsx
+++ b/apps/web/components/backtest-run-shell.tsx
@@ -1,6 +1,32 @@
+"use client";
+
 import Link from "next/link";
+import useSWR from "swr";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 import { ConsoleNav } from "@/components/console-nav";
+import {
+  buildAnalysisMetrics,
+  formatCount,
+  formatMoney,
+  formatPercent,
+  formatSigned,
+  formatSignedPercent,
+  formatTimestamp,
+} from "@/lib/dashboard-metrics";
+import {
+  fetchJson,
+  type ArtifactListResponse,
+  type BacktestRunDetailResponse,
+} from "@/lib/perpfut-api";
 
 
 function ShellPanel({
@@ -33,7 +59,470 @@ function ShellHeader({
   );
 }
 
+function LoadingState() {
+  return (
+    <ShellPanel className="p-5">
+      <ShellHeader eyebrow="Backtest Detail" title="Loading backtest artifacts" />
+      <div className="signal-grid grid h-72 place-items-center border border-[var(--border)] text-sm text-[var(--muted)]">
+        Polling the local backtest API for detail, events, fills, and positions.
+      </div>
+    </ShellPanel>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <ShellPanel className="p-5">
+      <ShellHeader eyebrow="Backtest Detail" title="Unable to load backtest artifacts" />
+      <div className="border border-[rgba(255,109,123,0.38)] bg-[rgba(255,109,123,0.08)] p-4 text-sm leading-6 text-[var(--danger)]">
+        {message}
+      </div>
+    </ShellPanel>
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function metricTone(value: number | null | undefined): "accent" | "warning" | "text" {
+  if (typeof value !== "number") {
+    return "text";
+  }
+  if (value > 0) {
+    return "accent";
+  }
+  if (value < 0) {
+    return "warning";
+  }
+  return "text";
+}
+
+function valueClass(tone: "accent" | "warning" | "danger" | "text") {
+  if (tone === "accent") {
+    return "text-[var(--accent)]";
+  }
+  if (tone === "warning") {
+    return "text-[var(--warning)]";
+  }
+  if (tone === "danger") {
+    return "text-[var(--danger)]";
+  }
+  return "text-[var(--text)]";
+}
+
+function DetailMetric({
+  label,
+  value,
+  tone = "text",
+}: {
+  label: string;
+  value: string;
+  tone?: "accent" | "warning" | "danger" | "text";
+}) {
+  return (
+    <div className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-4">
+      <div className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">{label}</div>
+      <div className={`mt-3 text-sm leading-6 ${valueClass(tone)}`}>{value}</div>
+    </div>
+  );
+}
+
+function EmptyBlock({ message }: { message: string }) {
+  return (
+    <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
+      {message}
+    </div>
+  );
+}
+
+function PendingBlock({ message }: { message: string }) {
+  return (
+    <div className="signal-grid grid min-h-48 place-items-center border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm text-[var(--muted)]">
+      {message}
+    </div>
+  );
+}
+
+function PerformancePanel({ detail }: { detail: BacktestRunDetailResponse }) {
+  const metrics = buildAnalysisMetrics(detail.analysis);
+
+  return (
+    <>
+      <ShellPanel className="p-5">
+        <ShellHeader eyebrow="Performance" title="Canonical backtest analysis" action={`${formatCount(metrics.cycleCount)} cycles`} />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          <DetailMetric label="Total Return" value={formatSignedPercent(metrics.totalReturnPct)} tone="accent" />
+          <DetailMetric
+            label="Total P&L"
+            value={formatMoney(metrics.totalPnlUsd)}
+            tone={metricTone(metrics.totalPnlUsd)}
+          />
+          <DetailMetric label="Max Drawdown" value={formatPercent(metrics.maxDrawdownPct)} tone="warning" />
+          <DetailMetric label="Turnover" value={formatMoney(metrics.turnoverUsd)} />
+          <DetailMetric label="Fills" value={formatCount(metrics.fillCount)} />
+        </div>
+      </ShellPanel>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <ShellPanel className="p-5">
+          <ShellHeader eyebrow="Chart" title="Equity Curve" />
+          {metrics.equitySeries.length > 0 ? (
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={metrics.equitySeries}>
+                  <CartesianGrid stroke="rgba(143,214,255,0.08)" vertical={false} />
+                  <XAxis dataKey="label" stroke="rgba(144,164,191,0.72)" tickLine={false} axisLine={false} />
+                  <YAxis stroke="rgba(144,164,191,0.72)" tickLine={false} axisLine={false} width={48} />
+                  <Tooltip
+                    cursor={{ stroke: "rgba(143,214,255,0.18)" }}
+                    contentStyle={{
+                      background: "rgba(10,16,27,0.96)",
+                      border: "1px solid rgba(184,211,242,0.24)",
+                      color: "#ecf4ff",
+                    }}
+                  />
+                  <Line type="monotone" dataKey="value" stroke="var(--accent)" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <EmptyBlock message="No equity series available for this backtest run." />
+          )}
+        </ShellPanel>
+
+        <ShellPanel className="p-5">
+          <ShellHeader eyebrow="Chart" title="Drawdown Curve" />
+          {metrics.drawdownSeries.length > 0 ? (
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={metrics.drawdownSeries}>
+                  <CartesianGrid stroke="rgba(143,214,255,0.08)" vertical={false} />
+                  <XAxis dataKey="label" stroke="rgba(144,164,191,0.72)" tickLine={false} axisLine={false} />
+                  <YAxis stroke="rgba(144,164,191,0.72)" tickLine={false} axisLine={false} width={48} />
+                  <Tooltip
+                    cursor={{ stroke: "rgba(241,187,103,0.18)" }}
+                    contentStyle={{
+                      background: "rgba(10,16,27,0.96)",
+                      border: "1px solid rgba(184,211,242,0.24)",
+                      color: "#ecf4ff",
+                    }}
+                  />
+                  <Line type="monotone" dataKey="value" stroke="var(--warning)" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <EmptyBlock message="No drawdown series available for this backtest run." />
+          )}
+        </ShellPanel>
+
+        <ShellPanel className="p-5">
+          <ShellHeader eyebrow="Chart" title="Absolute Exposure Timeline" />
+          {metrics.exposureSeries.length > 0 ? (
+            <div className="h-64">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={metrics.exposureSeries}>
+                  <CartesianGrid stroke="rgba(143,214,255,0.08)" vertical={false} />
+                  <XAxis dataKey="label" stroke="rgba(144,164,191,0.72)" tickLine={false} axisLine={false} />
+                  <YAxis stroke="rgba(144,164,191,0.72)" tickLine={false} axisLine={false} width={48} />
+                  <Tooltip
+                    cursor={{ stroke: "rgba(143,214,255,0.18)" }}
+                    contentStyle={{
+                      background: "rgba(10,16,27,0.96)",
+                      border: "1px solid rgba(184,211,242,0.24)",
+                      color: "#ecf4ff",
+                    }}
+                  />
+                  <Line type="monotone" dataKey="value" stroke="var(--success)" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <EmptyBlock message="No exposure series available for this backtest run." />
+          )}
+        </ShellPanel>
+      </div>
+    </>
+  );
+}
+
+function PortfolioSnapshot({
+  detail,
+  positions,
+  positionsLoading,
+}: {
+  detail: BacktestRunDetailResponse;
+  positions: ArtifactListResponse | undefined;
+  positionsLoading: boolean;
+}) {
+  const portfolio = asRecord(detail.state.portfolio) ?? asRecord(detail.state.position);
+  const latestPositionRow = positions?.items[0] ? asRecord(positions.items[0]) : null;
+  const assetPositions = asRecord(latestPositionRow?.asset_positions) ?? asRecord(detail.state.asset_positions);
+  const manifest = detail.manifest;
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[0.95fr_1.05fr]">
+      <ShellPanel className="p-5">
+        <ShellHeader eyebrow="Portfolio" title="Latest portfolio checkpoint" action={String(detail.state.cycle_id ?? "--")} />
+        <div className="grid gap-4 md:grid-cols-2">
+          <DetailMetric
+            label="Ending Equity"
+            value={formatMoney(typeof portfolio?.equity_usdc === "number" ? portfolio.equity_usdc : detail.analysis.ending_equity_usdc)}
+            tone="accent"
+          />
+          <DetailMetric
+            label="Gross Notional"
+            value={formatMoney(typeof portfolio?.gross_notional_usdc === "number" ? portfolio.gross_notional_usdc : null)}
+          />
+          <DetailMetric
+            label="Realized P&L"
+            value={formatMoney(typeof portfolio?.realized_pnl_usdc === "number" ? portfolio.realized_pnl_usdc : detail.analysis.realized_pnl_usdc)}
+            tone={metricTone(typeof portfolio?.realized_pnl_usdc === "number" ? portfolio.realized_pnl_usdc : detail.analysis.realized_pnl_usdc)}
+          />
+          <DetailMetric
+            label="Unrealized P&L"
+            value={formatMoney(typeof portfolio?.unrealized_pnl_usdc === "number" ? portfolio.unrealized_pnl_usdc : detail.analysis.unrealized_pnl_usdc)}
+            tone={metricTone(typeof portfolio?.unrealized_pnl_usdc === "number" ? portfolio.unrealized_pnl_usdc : detail.analysis.unrealized_pnl_usdc)}
+          />
+          <DetailMetric label="Suite" value={String(manifest.suite_id ?? "--")} />
+          <DetailMetric label="Dataset" value={String(manifest.dataset_id ?? "--")} />
+        </div>
+      </ShellPanel>
+
+      <ShellPanel className="p-5">
+        <ShellHeader eyebrow="Assets" title="Latest per-asset positions" />
+        {positionsLoading && !assetPositions ? (
+          <PendingBlock message="Loading the latest per-asset position snapshot." />
+        ) : assetPositions ? (
+          <div className="overflow-x-auto border border-[var(--border)] bg-[var(--bg-elevated)]">
+            <table className="min-w-full text-left text-sm">
+              <thead className="border-b border-[var(--border)] text-[var(--muted)]">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Asset</th>
+                  <th className="px-4 py-3 font-medium">Quantity</th>
+                  <th className="px-4 py-3 font-medium">Entry</th>
+                  <th className="px-4 py-3 font-medium">Mark</th>
+                  <th className="px-4 py-3 font-medium">Realized</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.entries(assetPositions).map(([productId, value]) => {
+                  const position = asRecord(value);
+                  return (
+                    <tr key={productId} className="border-b border-[var(--border)] last:border-b-0">
+                      <td className="px-4 py-3 text-[var(--text)]">{productId}</td>
+                      <td className="px-4 py-3 text-[var(--text)]">
+                        {formatSigned(typeof position?.quantity === "number" ? position.quantity : null, 4)}
+                      </td>
+                      <td className="px-4 py-3 text-[var(--muted)]">
+                        {typeof position?.entry_price === "number" ? position.entry_price.toFixed(2) : "--"}
+                      </td>
+                      <td className="px-4 py-3 text-[var(--muted)]">
+                        {typeof position?.mark_price === "number" ? position.mark_price.toFixed(2) : "--"}
+                      </td>
+                      <td className="px-4 py-3 text-[var(--text)]">
+                        {formatMoney(typeof position?.realized_pnl_usdc === "number" ? position.realized_pnl_usdc : null)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <EmptyBlock message="No per-asset position snapshot was written for this backtest run." />
+        )}
+      </ShellPanel>
+    </div>
+  );
+}
+
+function DecisionPanel({
+  events,
+  eventsLoading,
+}: {
+  events: ArtifactListResponse | undefined;
+  eventsLoading: boolean;
+}) {
+  const latestEvent = events?.items[0] ? asRecord(events.items[0]) : null;
+  const assetDecisions = asRecord(latestEvent?.asset_decisions);
+
+  return (
+    <ShellPanel className="p-5">
+      <ShellHeader eyebrow="Decisions" title="Latest asset decision set" action={String(latestEvent?.cycle_id ?? "--")} />
+      {eventsLoading ? (
+        <PendingBlock message="Loading the latest asset decision set." />
+      ) : assetDecisions ? (
+        <div className="grid gap-4 xl:grid-cols-2">
+          {Object.entries(assetDecisions).map(([productId, value]) => {
+            const decision = asRecord(value);
+            const signal = asRecord(decision?.signal);
+            const risk = asRecord(decision?.risk_decision);
+            const execution = asRecord(decision?.execution_summary);
+            const noTrade = asRecord(decision?.no_trade_reason);
+            return (
+              <div key={productId} className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="text-sm font-medium text-[var(--text)]">{productId}</div>
+                  <div className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">
+                    {String(execution?.action ?? "unknown")}
+                  </div>
+                </div>
+                <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
+                  {typeof execution?.summary === "string"
+                    ? execution.summary
+                    : typeof noTrade?.message === "string"
+                      ? noTrade.message
+                      : "No execution summary available."}
+                </p>
+                <div className="mt-4 grid gap-3 md:grid-cols-2">
+                  <DetailMetric
+                    label="Signal Target"
+                    value={formatSigned(typeof signal?.target_position === "number" ? signal.target_position : null, 4)}
+                    tone="accent"
+                  />
+                  <DetailMetric
+                    label="Delta Notional"
+                    value={formatMoney(typeof risk?.delta_notional_usdc === "number" ? risk.delta_notional_usdc : null)}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <EmptyBlock message="No asset-level decision payload was found in the latest event." />
+      )}
+    </ShellPanel>
+  );
+}
+
+function FillPanel({
+  fills,
+  fillsLoading,
+}: {
+  fills: ArtifactListResponse | undefined;
+  fillsLoading: boolean;
+}) {
+  return (
+    <ShellPanel className="p-5">
+      <ShellHeader eyebrow="Fills" title="Recent backtest fill tape" action={`${fills?.count ?? 0} rows`} />
+      {fillsLoading ? (
+        <PendingBlock message="Loading recent backtest fills." />
+      ) : fills && fills.items.length > 0 ? (
+        <div className="overflow-x-auto border border-[var(--border)] bg-[var(--bg-elevated)]">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[var(--border)] text-[var(--muted)]">
+              <tr>
+                <th className="px-4 py-3 font-medium">Cycle</th>
+                <th className="px-4 py-3 font-medium">Asset</th>
+                <th className="px-4 py-3 font-medium">Side</th>
+                <th className="px-4 py-3 font-medium">Quantity</th>
+                <th className="px-4 py-3 font-medium">Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fills.items.map((row) => {
+                const item = asRecord(row);
+                const fill = asRecord(item?.fill);
+                return (
+                  <tr key={`${String(item?.cycle_id ?? "--")}-${String(item?.product_id ?? "--")}`} className="border-b border-[var(--border)] last:border-b-0">
+                    <td className="px-4 py-3 text-[var(--muted)]">{String(item?.cycle_id ?? "--")}</td>
+                    <td className="px-4 py-3 text-[var(--text)]">{String(item?.product_id ?? "--")}</td>
+                    <td className="px-4 py-3 text-[var(--text)]">{String(fill?.side ?? "--")}</td>
+                    <td className="px-4 py-3 text-[var(--muted)]">
+                      {typeof fill?.quantity === "number" ? fill.quantity.toFixed(6) : "--"}
+                    </td>
+                    <td className="px-4 py-3 text-[var(--muted)]">
+                      {typeof fill?.price === "number" ? fill.price.toFixed(2) : "--"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <EmptyBlock message="This backtest run has no recorded fills yet." />
+      )}
+    </ShellPanel>
+  );
+}
+
+function EventPanel({
+  events,
+  eventsLoading,
+}: {
+  events: ArtifactListResponse | undefined;
+  eventsLoading: boolean;
+}) {
+  return (
+    <ShellPanel className="p-5">
+      <ShellHeader eyebrow="Events" title="Backtest event stream" action={`${events?.count ?? 0} rows`} />
+      {eventsLoading ? (
+        <PendingBlock message="Loading the backtest event stream." />
+      ) : events && events.items.length > 0 ? (
+        <div className="overflow-x-auto border border-[var(--border)] bg-[var(--bg-elevated)]">
+          <table className="min-w-full text-left text-sm">
+            <thead className="border-b border-[var(--border)] text-[var(--muted)]">
+              <tr>
+                <th className="px-4 py-3 font-medium">Cycle</th>
+                <th className="px-4 py-3 font-medium">Action</th>
+                <th className="px-4 py-3 font-medium">Reason</th>
+                <th className="px-4 py-3 font-medium">Summary</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.items.map((row) => {
+                const item = asRecord(row);
+                const execution = asRecord(item?.execution_summary);
+                const noTrade = asRecord(item?.no_trade_reason);
+                return (
+                  <tr key={String(item?.cycle_id ?? "--")} className="border-b border-[var(--border)] last:border-b-0">
+                    <td className="px-4 py-3 text-[var(--muted)]">{String(item?.cycle_id ?? "--")}</td>
+                    <td className="px-4 py-3 text-[var(--text)]">{String(execution?.action ?? "--")}</td>
+                    <td className="px-4 py-3 text-[var(--warning)]">
+                      {String(execution?.reason_code ?? noTrade?.code ?? "--")}
+                    </td>
+                    <td className="px-4 py-3 text-[var(--muted)]">
+                      {String(execution?.summary ?? noTrade?.message ?? "--")}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <EmptyBlock message="No event stream is available for this backtest run." />
+      )}
+    </ShellPanel>
+  );
+}
+
 export function BacktestRunShell({ runId }: { runId: string }) {
+  const detail = useSWR<BacktestRunDetailResponse>(`/backtests/${runId}`, fetchJson, {
+    refreshInterval: 2000,
+  });
+  const events = useSWR<ArtifactListResponse>(`/backtests/${runId}/events?limit=20`, fetchJson, {
+    refreshInterval: 2000,
+  });
+  const fills = useSWR<ArtifactListResponse>(`/backtests/${runId}/fills?limit=20`, fetchJson, {
+    refreshInterval: 2000,
+  });
+  const positions = useSWR<ArtifactListResponse>(`/backtests/${runId}/positions?limit=20`, fetchJson, {
+    refreshInterval: 2000,
+  });
+
+  const loading = !detail.data && !detail.error;
+  const eventsLoading = !events.data && !events.error;
+  const fillsLoading = !fills.data && !fills.error;
+  const positionsLoading = !positions.data && !positions.error;
+  const error = detail.error ?? events.error ?? fills.error ?? positions.error;
+
   return (
     <main className="min-h-screen px-4 py-4 text-[var(--text)] sm:px-6 lg:px-8">
       <div className="mx-auto grid max-w-[1680px] gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
@@ -54,8 +543,23 @@ export function BacktestRunShell({ runId }: { runId: string }) {
               </div>
               <div className="mt-3 text-sm text-[var(--text)]">{runId}</div>
               <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
-                This permanent route shell is in place. The full analysis, fill tape, and decision drill-down
-                wiring land in the next run-detail PR.
+                {detail.data
+                  ? `${String(detail.data.manifest.strategy_id ?? "--")} · ${String(detail.data.manifest.suite_id ?? "--")}`
+                  : "Waiting for the backtest detail payload."}
+              </p>
+            </div>
+
+            <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
+              <div className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--warning)]">
+                Analysis Window
+              </div>
+              <div className="mt-3 text-sm text-[var(--text)]">
+                {detail.data ? formatTimestamp(detail.data.analysis.ended_at) : "--"}
+              </div>
+              <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
+                {detail.data
+                  ? `${formatCount(detail.data.analysis.fill_count)} fills · ${formatCount(detail.data.analysis.cycle_count)} cycles`
+                  : "No analysis summary loaded yet."}
               </p>
             </div>
           </div>
@@ -71,8 +575,8 @@ export function BacktestRunShell({ runId }: { runId: string }) {
                 Run Detail: {runId}
               </h1>
               <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--muted)]">
-                This route will render canonical analysis, decisions, fills, and per-asset portfolio views
-                from the backtest API. The shell exists now so the navigation and URL model are stable.
+                This page reads the canonical backtest detail payload plus recent artifacts and surfaces
+                analysis, per-asset decisions, fills, and portfolio inspection without raw JSON digging.
               </p>
             </div>
             <Link
@@ -83,30 +587,20 @@ export function BacktestRunShell({ runId }: { runId: string }) {
             </Link>
           </header>
 
-          <div className="grid gap-4 lg:grid-cols-3">
-            <ShellPanel className="p-5">
-              <ShellHeader eyebrow="Analysis" title="Canonical metrics panel" action="BT-10" />
-              <div className="min-h-48 border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
-                Equity, drawdown, turnover, and exposure summaries will render here from the canonical
-                analysis contract.
-              </div>
-            </ShellPanel>
+          {loading ? <LoadingState /> : null}
+          {error ? <ErrorState message={error.message} /> : null}
 
-            <ShellPanel className="p-5">
-              <ShellHeader eyebrow="Decisions" title="Decision drill-down" action="BT-10" />
-              <div className="min-h-48 border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
-                Cycle-level explanations and no-trade reasons for the selected backtest run land in the next
-                frontend step.
+          {detail.data && !error ? (
+            <>
+              <PerformancePanel detail={detail.data} />
+              <PortfolioSnapshot detail={detail.data} positions={positions.data} positionsLoading={positionsLoading} />
+              <DecisionPanel events={events.data} eventsLoading={eventsLoading} />
+              <div className="grid gap-4 xl:grid-cols-[0.95fr_1.05fr]">
+                <FillPanel fills={fills.data} fillsLoading={fillsLoading} />
+                <EventPanel events={events.data} eventsLoading={eventsLoading} />
               </div>
-            </ShellPanel>
-
-            <ShellPanel className="p-5">
-              <ShellHeader eyebrow="Assets" title="Per-asset inspection" action="BT-10" />
-              <div className="min-h-48 border border-[var(--border)] bg-[var(--bg-elevated)] p-5 text-sm leading-6 text-[var(--muted)]">
-                Per-asset positions, fills, and contribution views are reserved for the full detail page.
-              </div>
-            </ShellPanel>
-          </div>
+            </>
+          ) : null}
         </section>
       </div>
     </main>

--- a/apps/web/components/backtests-shell.test.tsx
+++ b/apps/web/components/backtests-shell.test.tsx
@@ -12,6 +12,16 @@ vi.mock("next/link", () => ({
   default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
 }));
 
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  LineChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CartesianGrid: () => null,
+  Line: () => null,
+  Tooltip: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+}));
+
 vi.mock("@/lib/perpfut-api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/perpfut-api")>("@/lib/perpfut-api");
   return {
@@ -162,6 +172,106 @@ describe("BacktestsShell", () => {
     expect(screen.getByText("backtest api unavailable")).toBeInTheDocument();
   });
 
+  it("switches leaderboard data when a different suite is selected", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path === "/backtests") {
+        return { items: [], count: 0, active_job: null };
+      }
+      if (path === "/backtest-suites") {
+        return {
+          items: [
+            {
+              suite_id: "suite-1",
+              created_at: "2026-03-22T06:00:00Z",
+              dataset_id: "dataset-1",
+              products: ["BTC-PERP-INTX"],
+              strategies: ["momentum"],
+              run_ids: ["run-1"],
+            },
+            {
+              suite_id: "suite-2",
+              created_at: "2026-03-22T07:00:00Z",
+              dataset_id: "dataset-2",
+              products: ["ETH-PERP-INTX"],
+              strategies: ["mean_reversion"],
+              run_ids: ["run-2"],
+            },
+          ],
+          count: 2,
+          active_job: null,
+        };
+      }
+      if (path === "/backtest-suites/suite-1") {
+        return {
+          suite_id: "suite-1",
+          created_at: "2026-03-22T06:00:00Z",
+          dataset_id: "dataset-1",
+          products: ["BTC-PERP-INTX"],
+          strategies: ["momentum"],
+          run_ids: ["run-1"],
+          ranking_policy: "return desc",
+          items: [
+            {
+              rank: 1,
+              run_id: "run-1",
+              strategy_id: "momentum",
+              total_pnl_usdc: 120,
+              total_return_pct: 0.012,
+              max_drawdown_usdc: 40,
+              max_drawdown_pct: 0.004,
+              turnover_usdc: 5000,
+              fill_count: 3,
+              avg_abs_exposure_pct: 0.22,
+              max_abs_exposure_pct: 0.35,
+              decision_counts: { filled: 3 },
+            },
+          ],
+        };
+      }
+      if (path === "/backtest-suites/suite-2") {
+        return {
+          suite_id: "suite-2",
+          created_at: "2026-03-22T07:00:00Z",
+          dataset_id: "dataset-2",
+          products: ["ETH-PERP-INTX"],
+          strategies: ["mean_reversion"],
+          run_ids: ["run-2"],
+          ranking_policy: "return desc",
+          items: [
+            {
+              rank: 1,
+              run_id: "run-2",
+              strategy_id: "mean_reversion",
+              total_pnl_usdc: 80,
+              total_return_pct: 0.008,
+              max_drawdown_usdc: 20,
+              max_drawdown_pct: 0.002,
+              turnover_usdc: 3200,
+              fill_count: 2,
+              avg_abs_exposure_pct: 0.11,
+              max_abs_exposure_pct: 0.2,
+              decision_counts: { filled: 2 },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderBacktestsShell();
+
+    expect(await screen.findByRole("link", { name: "momentum" })).toHaveAttribute(
+      "href",
+      "/backtests/run-1"
+    );
+    await userEvent.click(screen.getByRole("button", { name: /suite-2/i }));
+
+    expect(await screen.findByRole("link", { name: "mean_reversion" })).toHaveAttribute(
+      "href",
+      "/backtests/run-2"
+    );
+  });
+
   it("shows a validation warning when a datetime input is cleared", async () => {
     mockedFetchJson.mockImplementation(async (path: string) => {
       if (path === "/backtests") {
@@ -185,11 +295,202 @@ describe("BacktestsShell", () => {
 });
 
 describe("BacktestRunShell", () => {
-  it("renders the backtest run detail shell with a stable route model", () => {
-    render(<BacktestRunShell runId="suite-run-1" />);
+  it("renders backtest analysis, decisions, fills, and per-asset positions", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path === "/backtests/suite-run-1") {
+        return {
+          run_id: "suite-run-1",
+          manifest: {
+            run_id: "suite-run-1",
+            suite_id: "suite-1",
+            dataset_id: "dataset-1",
+            strategy_id: "momentum",
+          },
+          state: {
+            cycle_id: "cycle-4",
+            portfolio: {
+              equity_usdc: 10120,
+              gross_notional_usdc: 4200,
+              realized_pnl_usdc: 70,
+              unrealized_pnl_usdc: 50,
+            },
+            asset_positions: {
+              "BTC-PERP-INTX": {
+                quantity: 0.12,
+                entry_price: 100,
+                mark_price: 103,
+                realized_pnl_usdc: 40,
+              },
+            },
+          },
+          analysis: {
+            run_id: "suite-run-1",
+            mode: "backtest",
+            product_id: "MULTI_ASSET",
+            strategy_id: "momentum",
+            started_at: "2026-03-22T02:00:00Z",
+            ended_at: "2026-03-22T02:10:00Z",
+            cycle_count: 12,
+            starting_equity_usdc: 10000,
+            ending_equity_usdc: 10120,
+            realized_pnl_usdc: 70,
+            unrealized_pnl_usdc: 50,
+            total_pnl_usdc: 120,
+            total_return_pct: 0.012,
+            max_drawdown_usdc: 35,
+            max_drawdown_pct: 0.0035,
+            turnover_usdc: 4800,
+            fill_count: 3,
+            trade_count: 3,
+            avg_abs_exposure_pct: 0.22,
+            max_abs_exposure_pct: 0.35,
+            decision_counts: { filled: 3 },
+            equity_series: [{ label: "c1", value: 10000 }, { label: "c12", value: 10120 }],
+            drawdown_series: [{ label: "c1", value: 0 }, { label: "c12", value: 35 }],
+            exposure_series: [{ label: "c1", value: 0.1 }, { label: "c12", value: 0.22 }],
+          },
+        };
+      }
+      if (path === "/backtests/suite-run-1/events?limit=20") {
+        return {
+          run_id: "suite-run-1",
+          count: 1,
+          items: [
+            {
+              cycle_id: "cycle-4",
+              execution_summary: {
+                action: "filled",
+                reason_code: "filled",
+                summary: "Filled one asset toward target.",
+              },
+              asset_decisions: {
+                "BTC-PERP-INTX": {
+                  signal: { target_position: 0.25 },
+                  risk_decision: { delta_notional_usdc: 1500 },
+                  execution_summary: { action: "filled", summary: "Filled BTC rebalance." },
+                },
+              },
+            },
+          ],
+        };
+      }
+      if (path === "/backtests/suite-run-1/fills?limit=20") {
+        return {
+          run_id: "suite-run-1",
+          count: 1,
+          items: [
+            {
+              cycle_id: "cycle-4",
+              product_id: "BTC-PERP-INTX",
+              fill: { side: "BUY", quantity: 0.02, price: 103 },
+            },
+          ],
+        };
+      }
+      if (path === "/backtests/suite-run-1/positions?limit=20") {
+        return {
+          run_id: "suite-run-1",
+          count: 1,
+          items: [
+            {
+              cycle_id: "cycle-4",
+              asset_positions: {
+                "BTC-PERP-INTX": {
+                  quantity: 0.12,
+                  entry_price: 100,
+                  mark_price: 103,
+                  realized_pnl_usdc: 40,
+                },
+              },
+            },
+          ],
+        };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
 
-    expect(screen.getByText("Run Detail: suite-run-1")).toBeInTheDocument();
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <BacktestRunShell runId="suite-run-1" />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Canonical backtest analysis")).toBeInTheDocument();
+    expect(screen.getByText("Latest asset decision set")).toBeInTheDocument();
+    expect(screen.getByText("Recent backtest fill tape")).toBeInTheDocument();
+    expect(screen.getByText("Latest per-asset positions")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Back to Backtests/i })).toHaveAttribute("href", "/backtests");
-    expect(screen.getByText("Per-asset inspection")).toBeInTheDocument();
+  });
+
+  it("keeps artifact panels in loading state while secondary requests are still pending", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path === "/backtests/suite-run-2") {
+        return {
+          run_id: "suite-run-2",
+          manifest: {
+            run_id: "suite-run-2",
+            suite_id: "suite-2",
+            dataset_id: "dataset-2",
+            strategy_id: "momentum",
+          },
+          state: {
+            cycle_id: "cycle-2",
+            portfolio: {
+              equity_usdc: 10020,
+              gross_notional_usdc: 1200,
+              realized_pnl_usdc: 15,
+              unrealized_pnl_usdc: 5,
+            },
+          },
+          analysis: {
+            run_id: "suite-run-2",
+            mode: "backtest",
+            product_id: "MULTI_ASSET",
+            strategy_id: "momentum",
+            started_at: "2026-03-22T03:00:00Z",
+            ended_at: "2026-03-22T03:05:00Z",
+            cycle_count: 6,
+            starting_equity_usdc: 10000,
+            ending_equity_usdc: 10020,
+            realized_pnl_usdc: 15,
+            unrealized_pnl_usdc: 5,
+            total_pnl_usdc: 20,
+            total_return_pct: 0.002,
+            max_drawdown_usdc: 10,
+            max_drawdown_pct: 0.001,
+            turnover_usdc: 900,
+            fill_count: 1,
+            trade_count: 1,
+            avg_abs_exposure_pct: 0.08,
+            max_abs_exposure_pct: 0.12,
+            decision_counts: { filled: 1 },
+            equity_series: [{ label: "c1", value: 10000 }, { label: "c6", value: 10020 }],
+            drawdown_series: [{ label: "c1", value: 0 }, { label: "c6", value: 10 }],
+            exposure_series: [{ label: "c1", value: 0 }, { label: "c6", value: 0.08 }],
+          },
+        };
+      }
+      if (
+        path === "/backtests/suite-run-2/events?limit=20" ||
+        path === "/backtests/suite-run-2/fills?limit=20" ||
+        path === "/backtests/suite-run-2/positions?limit=20"
+      ) {
+        return new Promise(() => {});
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <BacktestRunShell runId="suite-run-2" />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Canonical backtest analysis")).toBeInTheDocument();
+    expect(screen.getByText("Loading the latest asset decision set.")).toBeInTheDocument();
+    expect(screen.getByText("Loading recent backtest fills.")).toBeInTheDocument();
+    expect(screen.getByText("Loading the backtest event stream.")).toBeInTheDocument();
+    expect(screen.queryByText("This backtest run has no recorded fills yet.")).not.toBeInTheDocument();
+    expect(screen.queryByText("No event stream is available for this backtest run.")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/lib/perpfut-api.ts
+++ b/apps/web/lib/perpfut-api.ts
@@ -226,6 +226,13 @@ export type BacktestSuiteDetailResponse = {
   items: BacktestSuiteComparisonItem[];
 };
 
+export type BacktestRunDetailResponse = {
+  run_id: string;
+  manifest: Record<string, unknown>;
+  state: Record<string, unknown>;
+  analysis: RunAnalysisResponse;
+};
+
 const API_BASE = "/api/perpfut";
 
 export class ApiError extends Error {


### PR DESCRIPTION
## Summary
- build the backtest run detail page against the new backtest API surfaces
- render canonical performance metrics, charts, per-asset positions, fills, and decision summaries
- extend frontend types and tests for the detailed backtest artifact view

Closes #66