### PR TITLE
[BTX-3] Surface backtest progress and reporting in the UI

### DIFF
--- a/apps/web/components/backtest-run-shell.tsx
+++ b/apps/web/components/backtest-run-shell.tsx
@@ -15,9 +15,11 @@ import {
 import { ConsoleNav } from "@/components/console-nav";
 import {
   buildAnalysisMetrics,
+  formatDateRange,
   formatCount,
   formatMoney,
   formatPercent,
+  formatSharpe,
   formatSigned,
   formatSignedPercent,
   formatTimestamp,
@@ -153,7 +155,7 @@ function PerformancePanel({ detail }: { detail: BacktestRunDetailResponse }) {
     <>
       <ShellPanel className="p-5">
         <ShellHeader eyebrow="Performance" title="Canonical backtest analysis" action={`${formatCount(metrics.cycleCount)} cycles`} />
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           <DetailMetric label="Total Return" value={formatSignedPercent(metrics.totalReturnPct)} tone="accent" />
           <DetailMetric
             label="Total P&L"
@@ -161,6 +163,11 @@ function PerformancePanel({ detail }: { detail: BacktestRunDetailResponse }) {
             tone={metricTone(metrics.totalPnlUsd)}
           />
           <DetailMetric label="Max Drawdown" value={formatPercent(metrics.maxDrawdownPct)} tone="warning" />
+          <DetailMetric label="Sharpe" value={formatSharpe(detail.analysis.sharpe_ratio)} />
+          <DetailMetric
+            label="Date Range"
+            value={formatDateRange(detail.analysis.date_range_start, detail.analysis.date_range_end)}
+          />
           <DetailMetric label="Turnover" value={formatMoney(metrics.turnoverUsd)} />
           <DetailMetric label="Fills" value={formatCount(metrics.fillCount)} />
         </div>
@@ -554,11 +561,13 @@ export function BacktestRunShell({ runId }: { runId: string }) {
                 Analysis Window
               </div>
               <div className="mt-3 text-sm text-[var(--text)]">
-                {detail.data ? formatTimestamp(detail.data.analysis.ended_at) : "--"}
+                {detail.data
+                  ? formatDateRange(detail.data.analysis.date_range_start, detail.data.analysis.date_range_end)
+                  : "--"}
               </div>
               <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
                 {detail.data
-                  ? `${formatCount(detail.data.analysis.fill_count)} fills · ${formatCount(detail.data.analysis.cycle_count)} cycles`
+                  ? `${formatSharpe(detail.data.analysis.sharpe_ratio)} Sharpe · ${formatCount(detail.data.analysis.fill_count)} fills · ${formatCount(detail.data.analysis.cycle_count)} cycles`
                   : "No analysis summary loaded yet."}
               </p>
             </div>

--- a/apps/web/components/backtests-shell.test.tsx
+++ b/apps/web/components/backtests-shell.test.tsx
@@ -68,8 +68,11 @@ describe("BacktestsShell", () => {
               created_at: "2026-03-22T06:00:00Z",
               suite_id: "suite-1",
               dataset_id: "dataset-1",
+              date_range_start: "2026-03-20T12:00:00+00:00",
+              date_range_end: "2026-03-21T12:00:00+00:00",
               product_id: "MULTI_ASSET",
               strategy_id: "momentum",
+              sharpe_ratio: 1.87,
               total_pnl_usdc: 120,
               total_return_pct: 0.012,
               max_drawdown_usdc: 40,
@@ -81,7 +84,42 @@ describe("BacktestsShell", () => {
             },
           ],
           count: 1,
-          active_job: null,
+          active_job: {
+            job_id: "job-1",
+            status: "running",
+            phase: "running_suite",
+            phase_message: "Completed strategy 1 of 2: momentum",
+            pid: 4001,
+            created_at: "2026-03-22T06:05:00Z",
+            started_at: "2026-03-22T06:05:00Z",
+            finished_at: null,
+            total_runs: 2,
+            completed_runs: 1,
+            progress_pct: 0.5,
+            elapsed_seconds: 90,
+            eta_seconds: 90,
+            last_heartbeat_at: "2026-03-22T06:06:00Z",
+            suite_id: null,
+            dataset_id: null,
+            run_ids: [],
+            error: null,
+            log_path: "runs/backtests/control/job-1.log",
+            request: {
+              productIds: ["BTC-PERP-INTX", "ETH-PERP-INTX"],
+              strategyIds: ["momentum", "mean_reversion"],
+              start: "2026-03-21T12:00:00+00:00",
+              end: "2026-03-22T12:00:00+00:00",
+              granularity: "ONE_MINUTE",
+              startingCollateralUsdc: 10000,
+              lookbackCandles: 20,
+              signalScale: 12,
+              maxAbsPosition: 0.5,
+              maxGrossPosition: 1.0,
+              maxLeverage: 2.0,
+              slippageBps: 3,
+            },
+          },
+          latest_job: null,
         };
       }
       if (path === "/backtest-suites") {
@@ -91,6 +129,9 @@ describe("BacktestsShell", () => {
               suite_id: "suite-1",
               created_at: "2026-03-22T06:00:00Z",
               dataset_id: "dataset-1",
+              date_range_start: "2026-03-20T12:00:00+00:00",
+              date_range_end: "2026-03-21T12:00:00+00:00",
+              sharpe_ratio: 1.87,
               products: ["BTC-PERP-INTX", "ETH-PERP-INTX"],
               strategies: ["momentum", "mean_reversion"],
               run_ids: ["run-2", "run-1"],
@@ -98,6 +139,7 @@ describe("BacktestsShell", () => {
           ],
           count: 1,
           active_job: null,
+          latest_job: null,
         };
       }
       if (path === "/backtest-suites/suite-1") {
@@ -105,6 +147,9 @@ describe("BacktestsShell", () => {
           suite_id: "suite-1",
           created_at: "2026-03-22T06:00:00Z",
           dataset_id: "dataset-1",
+          date_range_start: "2026-03-20T12:00:00+00:00",
+          date_range_end: "2026-03-21T12:00:00+00:00",
+          sharpe_ratio: 1.87,
           products: ["BTC-PERP-INTX", "ETH-PERP-INTX"],
           strategies: ["momentum", "mean_reversion"],
           run_ids: ["run-2", "run-1"],
@@ -114,6 +159,9 @@ describe("BacktestsShell", () => {
               rank: 1,
               run_id: "run-2",
               strategy_id: "momentum",
+              date_range_start: "2026-03-20T12:00:00+00:00",
+              date_range_end: "2026-03-21T12:00:00+00:00",
+              sharpe_ratio: 1.87,
               total_pnl_usdc: 120,
               total_return_pct: 0.012,
               max_drawdown_usdc: 40,
@@ -132,10 +180,18 @@ describe("BacktestsShell", () => {
     mockedStartBacktest.mockResolvedValue({
       job_id: "job-1",
       status: "running",
+      phase: "running_suite",
+      phase_message: "Completed strategy 1 of 2: momentum",
       pid: 4001,
       created_at: "2026-03-22T06:05:00Z",
       started_at: "2026-03-22T06:05:00Z",
       finished_at: null,
+      total_runs: 2,
+      completed_runs: 1,
+      progress_pct: 0.5,
+      elapsed_seconds: 90,
+      eta_seconds: 90,
+      last_heartbeat_at: "2026-03-22T06:06:00Z",
       suite_id: null,
       dataset_id: null,
       run_ids: [],
@@ -162,6 +218,8 @@ describe("BacktestsShell", () => {
     expect(await screen.findByText("Start a backtest suite")).toBeInTheDocument();
     expect(screen.getByText("Selected suite ranking")).toBeInTheDocument();
     expect(screen.getByText("Completed backtest runs")).toBeInTheDocument();
+    expect((await screen.findAllByText("Completed strategy 1 of 2: momentum")).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("1.87").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: "run-2" })).toHaveAttribute("href", "/backtests/run-2");
 
     await userEvent.click(screen.getByRole("button", { name: "SOL-PERP-INTX" }));
@@ -354,6 +412,55 @@ describe("BacktestsShell", () => {
     await waitFor(() => expect(mockedStartBacktest).toHaveBeenCalledTimes(1));
     expect(await screen.findByText("backtest job already running")).toBeInTheDocument();
   });
+
+  it("renders the latest failed job when no backtest is currently active", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path === "/backtests") {
+        return {
+          items: [],
+          count: 0,
+          active_job: null,
+          latest_job: {
+            job_id: "job-failed",
+            status: "failed",
+            phase: "failed",
+            phase_message: "Backtest suite failed.",
+            pid: null,
+            created_at: "2026-03-22T08:00:00Z",
+            started_at: "2026-03-22T08:00:00Z",
+            finished_at: "2026-03-22T08:03:00Z",
+            total_runs: 2,
+            completed_runs: 1,
+            progress_pct: 0.5,
+            elapsed_seconds: 180,
+            eta_seconds: 0,
+            last_heartbeat_at: "2026-03-22T08:02:00Z",
+            suite_id: null,
+            dataset_id: null,
+            run_ids: [],
+            error: "backtest run failed: boom",
+            log_path: "runs/backtests/control/job-failed.log",
+            request: {
+              productIds: ["BTC-PERP-INTX"],
+              strategyIds: ["momentum", "mean_reversion"],
+              start: "2026-03-21T12:00:00+00:00",
+              end: "2026-03-22T12:00:00+00:00",
+              granularity: "ONE_MINUTE",
+            },
+          },
+        };
+      }
+      if (path === "/backtest-suites") {
+        return { items: [], count: 0, active_job: null, latest_job: null };
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderBacktestsShell();
+
+    expect(await screen.findByText("FAILED · job-failed")).toBeInTheDocument();
+    expect(screen.getByText("backtest run failed: boom")).toBeInTheDocument();
+  });
 });
 
 describe("BacktestRunShell", () => {
@@ -392,6 +499,9 @@ describe("BacktestRunShell", () => {
             strategy_id: "momentum",
             started_at: "2026-03-22T02:00:00Z",
             ended_at: "2026-03-22T02:10:00Z",
+            date_range_start: "2026-03-20T12:00:00+00:00",
+            date_range_end: "2026-03-21T12:00:00+00:00",
+            sharpe_ratio: 1.52,
             cycle_count: 12,
             starting_equity_usdc: 10000,
             ending_equity_usdc: 10120,
@@ -477,6 +587,7 @@ describe("BacktestRunShell", () => {
     expect(screen.getByText("Latest asset decision set")).toBeInTheDocument();
     expect(screen.getByText("Recent backtest fill tape")).toBeInTheDocument();
     expect(screen.getByText("Latest per-asset positions")).toBeInTheDocument();
+    expect(screen.getAllByText("1.52").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Back to Backtests/i })).toHaveAttribute("href", "/backtests");
   });
 

--- a/apps/web/components/backtests-shell.tsx
+++ b/apps/web/components/backtests-shell.tsx
@@ -6,9 +6,12 @@ import useSWR from "swr";
 
 import { ConsoleNav } from "@/components/console-nav";
 import {
+  formatDateRange,
   formatCount,
+  formatDurationSeconds,
   formatMoney,
   formatPercent,
+  formatSharpe,
   formatSignedPercent,
   formatTimestamp,
 } from "@/lib/dashboard-metrics";
@@ -105,14 +108,28 @@ function ShellHeader({
 function MetricChip({
   label,
   value,
+  tone = "text",
 }: {
   label: string;
   value: string;
+  tone?: "accent" | "warning" | "danger" | "text";
 }) {
   return (
     <div className="border border-[var(--border)] bg-[var(--bg-elevated)] px-4 py-4">
       <div className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--muted)]">{label}</div>
-      <div className="mt-3 text-sm text-[var(--text)]">{value}</div>
+      <div
+        className={`mt-3 text-sm ${
+          tone === "accent"
+            ? "text-[var(--accent)]"
+            : tone === "warning"
+              ? "text-[var(--warning)]"
+              : tone === "danger"
+                ? "text-[var(--danger)]"
+                : "text-[var(--text)]"
+        }`}
+      >
+        {value}
+      </div>
     </div>
   );
 }
@@ -144,6 +161,26 @@ function formatControlError(error: unknown): ControlFeedback {
     tone: "danger",
     message: "Unable to start the backtest suite.",
   };
+}
+
+function jobTone(status: string | null | undefined): "accent" | "warning" | "danger" | "text" {
+  if (status === "running") {
+    return "accent";
+  }
+  if (status === "succeeded") {
+    return "warning";
+  }
+  if (status === "failed") {
+    return "danger";
+  }
+  return "text";
+}
+
+function jobStatusLabel(status: string | null | undefined): string {
+  if (!status) {
+    return "idle";
+  }
+  return status;
 }
 
 function toggleSelection(items: string[], value: string): string[] {
@@ -322,7 +359,12 @@ export function BacktestsShell() {
     }
   }
 
-  const activeJob = backtests.data?.active_job ?? suites.data?.active_job ?? null;
+  const activeJob =
+    backtests.data?.active_job ??
+    suites.data?.active_job ??
+    backtests.data?.latest_job ??
+    suites.data?.latest_job ??
+    null;
   const latestSuite = suites.data?.items[0] ?? null;
   const hasConsoleError = backtests.error || suites.error;
 
@@ -343,14 +385,25 @@ export function BacktestsShell() {
           <div className="space-y-4">
             <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
               <div className="mono text-[10px] uppercase tracking-[0.28em] text-[var(--warning)]">
-                Active Job
+                Backtest Status
               </div>
-              <div className="mt-3 text-sm text-[var(--text)]">
-                {activeJob ? `${activeJob.status.toUpperCase()} · ${activeJob.job_id}` : "No active backtest job"}
+              <div
+                className={`mt-3 text-sm ${
+                  jobTone(activeJob?.status) === "accent"
+                    ? "text-[var(--accent)]"
+                    : jobTone(activeJob?.status) === "warning"
+                      ? "text-[var(--warning)]"
+                      : jobTone(activeJob?.status) === "danger"
+                        ? "text-[var(--danger)]"
+                        : "text-[var(--text)]"
+                }`}
+              >
+                {activeJob ? `${jobStatusLabel(activeJob.status).toUpperCase()} · ${activeJob.job_id}` : "No recent backtest job"}
               </div>
               <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
                 {activeJob
-                  ? `${activeJob.request.productIds.join(", ")} · ${activeJob.request.strategyIds.join(", ")}`
+                  ? activeJob.phase_message ??
+                    `${activeJob.request.productIds.join(", ")} · ${activeJob.request.strategyIds.join(", ")}`
                   : "Launch a suite to populate the shared historical backtest queue."}
               </p>
             </div>
@@ -365,6 +418,13 @@ export function BacktestsShell() {
                   <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
                     {latestSuite.strategies.join(", ")} · {latestSuite.products.join(", ")}
                   </p>
+                  <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                    <MetricChip
+                      label="Date Range"
+                      value={formatDateRange(latestSuite.date_range_start, latestSuite.date_range_end)}
+                    />
+                    <MetricChip label="Sharpe" value={formatSharpe(latestSuite.sharpe_ratio)} />
+                  </div>
                 </>
               ) : (
                 <p className="mt-3 text-sm leading-6 text-[var(--muted)]">
@@ -400,7 +460,9 @@ export function BacktestsShell() {
               </div>
               <div className="border border-[var(--border)] px-3 py-3">
                 <div className="mono text-[10px] text-[var(--accent)]">Queue</div>
-                <div className="mt-2 text-sm text-[var(--text)]">{activeJob ? "1 active" : "idle"}</div>
+                <div className="mt-2 text-sm text-[var(--text)]">
+                  {activeJob?.status === "running" ? "1 active" : activeJob ? activeJob.status : "idle"}
+                </div>
               </div>
             </div>
           </header>
@@ -535,33 +597,51 @@ export function BacktestsShell() {
               {activeJob ? (
                 <div className="space-y-4">
                   <div className="border border-[var(--border)] bg-[var(--bg-elevated)] p-4">
-                    <div className="mono text-[10px] uppercase tracking-[0.24em] text-[var(--accent)]">
+                    <div
+                      className={`mono text-[10px] uppercase tracking-[0.24em] ${
+                        jobTone(activeJob.status) === "accent"
+                          ? "text-[var(--accent)]"
+                          : jobTone(activeJob.status) === "warning"
+                            ? "text-[var(--warning)]"
+                            : jobTone(activeJob.status) === "danger"
+                              ? "text-[var(--danger)]"
+                              : "text-[var(--muted)]"
+                      }`}
+                    >
                       {activeJob.status}
                     </div>
                     <div className="mt-3 text-base font-medium text-[var(--text)]">{activeJob.job_id}</div>
                     <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
-                      {activeJob.request.productIds.join(", ")} · {activeJob.request.strategyIds.join(", ")}
+                      {activeJob.phase_message ??
+                        `${activeJob.request.productIds.join(", ")} · ${activeJob.request.strategyIds.join(", ")}`}
                     </p>
                   </div>
-                  <div className="grid gap-4 md:grid-cols-2">
+                  <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                    <MetricChip label="Phase" value={activeJob.phase ?? "--"} tone={jobTone(activeJob.status)} />
+                    <MetricChip
+                      label="Progress"
+                      value={
+                        activeJob.total_runs
+                          ? `${formatCount(activeJob.completed_runs ?? 0)} / ${formatCount(activeJob.total_runs)} · ${formatPercent(activeJob.progress_pct)}`
+                          : "--"
+                      }
+                      tone={jobTone(activeJob.status)}
+                    />
+                    <MetricChip label="Elapsed" value={formatDurationSeconds(activeJob.elapsed_seconds)} />
+                    <MetricChip label="ETA" value={formatDurationSeconds(activeJob.eta_seconds)} />
+                    <MetricChip label="Heartbeat" value={formatTimestamp(activeJob.last_heartbeat_at)} />
                     <MetricChip label="Created" value={formatTimestamp(activeJob.created_at)} />
                     <MetricChip
                       label="Finished"
                       value={activeJob.finished_at ? formatTimestamp(activeJob.finished_at) : "running"}
                     />
-                    <MetricChip
-                      label="Suite"
-                      value={activeJob.suite_id ?? "pending"}
-                    />
-                    <MetricChip
-                      label="Run Count"
-                      value={formatCount(activeJob.run_ids.length)}
-                    />
+                    <MetricChip label="Suite" value={activeJob.suite_id ?? "pending"} />
+                    <MetricChip label="Run Count" value={formatCount(activeJob.run_ids.length)} />
                   </div>
                   {activeJob.error ? <ErrorBlock message={activeJob.error} /> : null}
                 </div>
               ) : (
-                <LoadingBlock title="No active backtest job. Launch a suite to populate this queue." />
+                <LoadingBlock title="No recent backtest job. Launch a suite to populate this queue." />
               )}
             </ShellPanel>
           </div>
@@ -597,6 +677,13 @@ export function BacktestsShell() {
                       <p className="mt-2 text-sm leading-6 text-[var(--muted)]">
                         {suite.strategies.join(", ")} · {suite.products.join(", ")}
                       </p>
+                      <div className="mt-3 grid gap-2 md:grid-cols-2">
+                        <MetricChip
+                          label="Date Range"
+                          value={formatDateRange(suite.date_range_start, suite.date_range_end)}
+                        />
+                        <MetricChip label="Sharpe" value={formatSharpe(suite.sharpe_ratio)} />
+                      </div>
                     </button>
                   ))}
                 </div>
@@ -622,6 +709,8 @@ export function BacktestsShell() {
                       <tr>
                         <th className="px-4 py-3 font-medium">Rank</th>
                         <th className="px-4 py-3 font-medium">Strategy</th>
+                        <th className="px-4 py-3 font-medium">Date Range</th>
+                        <th className="px-4 py-3 font-medium">Sharpe</th>
                         <th className="px-4 py-3 font-medium">Return</th>
                         <th className="px-4 py-3 font-medium">P&amp;L</th>
                         <th className="px-4 py-3 font-medium">Drawdown</th>
@@ -640,6 +729,10 @@ export function BacktestsShell() {
                               {item.strategy_id ?? item.run_id}
                             </Link>
                           </td>
+                          <td className="px-4 py-3 text-[var(--muted)]">
+                            {formatDateRange(item.date_range_start, item.date_range_end)}
+                          </td>
+                          <td className="px-4 py-3 text-[var(--text)]">{formatSharpe(item.sharpe_ratio)}</td>
                           <td className="px-4 py-3 text-[var(--accent)]">{formatSignedPercent(item.total_return_pct)}</td>
                           <td className="px-4 py-3 text-[var(--text)]">{formatMoney(item.total_pnl_usdc)}</td>
                           <td className="px-4 py-3 text-[var(--warning)]">{formatPercent(item.max_drawdown_pct)}</td>
@@ -671,6 +764,8 @@ export function BacktestsShell() {
                       <th className="px-4 py-3 font-medium">Run</th>
                       <th className="px-4 py-3 font-medium">Suite</th>
                       <th className="px-4 py-3 font-medium">Strategy</th>
+                      <th className="px-4 py-3 font-medium">Date Range</th>
+                      <th className="px-4 py-3 font-medium">Sharpe</th>
                       <th className="px-4 py-3 font-medium">Return</th>
                       <th className="px-4 py-3 font-medium">P&amp;L</th>
                       <th className="px-4 py-3 font-medium">Drawdown</th>
@@ -690,6 +785,10 @@ export function BacktestsShell() {
                         </td>
                         <td className="px-4 py-3 text-[var(--muted)]">{run.suite_id ?? "--"}</td>
                         <td className="px-4 py-3 text-[var(--text)]">{run.strategy_id ?? "--"}</td>
+                        <td className="px-4 py-3 text-[var(--muted)]">
+                          {formatDateRange(run.date_range_start, run.date_range_end)}
+                        </td>
+                        <td className="px-4 py-3 text-[var(--text)]">{formatSharpe(run.sharpe_ratio)}</td>
                         <td className="px-4 py-3 text-[var(--accent)]">{formatSignedPercent(run.total_return_pct)}</td>
                         <td className="px-4 py-3 text-[var(--text)]">{formatMoney(run.total_pnl_usdc)}</td>
                         <td className="px-4 py-3 text-[var(--warning)]">{formatPercent(run.max_drawdown_pct)}</td>

--- a/apps/web/lib/dashboard-metrics.ts
+++ b/apps/web/lib/dashboard-metrics.ts
@@ -113,3 +113,58 @@ export function formatTimestamp(value: string | null): string {
   }
   return new Date(parsed).toLocaleString();
 }
+
+export function formatDurationSeconds(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "--";
+  }
+  const rounded = Math.max(Math.round(value), 0);
+  const hours = Math.floor(rounded / 3600);
+  const minutes = Math.floor((rounded % 3600) / 60);
+  const seconds = rounded % 60;
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+export function formatSharpe(value: number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "--";
+  }
+  return value.toFixed(2);
+}
+
+export function formatDateRange(start: string | null | undefined, end: string | null | undefined): string {
+  if (!start && !end) {
+    return "--";
+  }
+  const formattedStart = formatCompactTimestamp(start);
+  const formattedEnd = formatCompactTimestamp(end);
+  if (formattedStart === "--") {
+    return formattedEnd;
+  }
+  if (formattedEnd === "--") {
+    return formattedStart;
+  }
+  return `${formattedStart} → ${formattedEnd}`;
+}
+
+function formatCompactTimestamp(value: string | null | undefined): string {
+  if (!value) {
+    return "--";
+  }
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}

--- a/apps/web/lib/perpfut-api.ts
+++ b/apps/web/lib/perpfut-api.ts
@@ -56,6 +56,9 @@ export type RunAnalysis = {
   strategy_id: string | null;
   started_at: string | null;
   ended_at: string | null;
+  date_range_start: string | null;
+  date_range_end: string | null;
+  sharpe_ratio: number | null;
   cycle_count: number;
   starting_equity_usdc: number;
   ending_equity_usdc: number;
@@ -150,10 +153,18 @@ export type BacktestRunRequest = {
 export type BacktestJobStatusResponse = {
   job_id: string;
   status: string;
+  phase: string | null;
+  phase_message: string | null;
   pid: number | null;
   created_at: string;
   started_at: string | null;
   finished_at: string | null;
+  total_runs: number | null;
+  completed_runs: number | null;
+  progress_pct: number | null;
+  elapsed_seconds: number | null;
+  eta_seconds: number | null;
+  last_heartbeat_at: string | null;
   suite_id: string | null;
   dataset_id: string | null;
   run_ids: string[];
@@ -167,8 +178,11 @@ export type BacktestRunSummary = {
   created_at: string | null;
   suite_id: string | null;
   dataset_id: string | null;
+  date_range_start: string | null;
+  date_range_end: string | null;
   product_id: string | null;
   strategy_id: string | null;
+  sharpe_ratio: number | null;
   total_pnl_usdc: number;
   total_return_pct: number;
   max_drawdown_usdc: number;
@@ -183,12 +197,16 @@ export type BacktestsListResponse = {
   items: BacktestRunSummary[];
   count: number;
   active_job: BacktestJobStatusResponse | null;
+  latest_job: BacktestJobStatusResponse | null;
 };
 
 export type BacktestSuiteSummary = {
   suite_id: string;
   created_at: string | null;
   dataset_id: string | null;
+  date_range_start: string | null;
+  date_range_end: string | null;
+  sharpe_ratio: number | null;
   products: string[];
   strategies: string[];
   run_ids: string[];
@@ -198,12 +216,16 @@ export type BacktestSuitesListResponse = {
   items: BacktestSuiteSummary[];
   count: number;
   active_job: BacktestJobStatusResponse | null;
+  latest_job: BacktestJobStatusResponse | null;
 };
 
 export type BacktestSuiteComparisonItem = {
   rank: number;
   run_id: string;
   strategy_id: string | null;
+  date_range_start: string | null;
+  date_range_end: string | null;
+  sharpe_ratio: number | null;
   total_pnl_usdc: number;
   total_return_pct: number;
   max_drawdown_usdc: number;
@@ -219,6 +241,9 @@ export type BacktestSuiteDetailResponse = {
   suite_id: string;
   created_at: string | null;
   dataset_id: string | null;
+  date_range_start: string | null;
+  date_range_end: string | null;
+  sharpe_ratio: number | null;
   products: string[];
   strategies: string[];
   run_ids: string[];


### PR DESCRIPTION
Closes #81

## Summary
- surface running and terminal backtest job state with progress, phase, elapsed time, ETA, and errors
- show date range and Sharpe across suite cards, leaderboard rows, run tables, and backtest run detail
- extend the frontend API contract and tests for the new backtest observability fields

## Validation
- cd apps/web && npm run test
- cd apps/web && npm run build