### PR TITLE
MS-5: add strategy instance research contract

### DIFF
--- a/docs/strategy-research.md
+++ b/docs/strategy-research.md
@@ -71,7 +71,8 @@ Allowed `risk_overrides` in v1:
 - duplicate products in `universe` are rejected
 - unknown parameter keys are rejected
 - `lookback_candles` must remain an integer
-- numeric overrides must be valid, and `max_gross_position` must remain positive
+- numeric strategy params and risk overrides must be finite, and `max_gross_position`
+  must remain positive
 
 ## Backward compatibility
 

--- a/src/perpfut/strategy_instances.py
+++ b/src/perpfut/strategy_instances.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -190,7 +191,10 @@ def _parse_strategy_params(value: Any, *, index: int, source: str) -> dict[str, 
             if numeric_value <= 0:
                 raise ValueError("lookback_candles must be positive")
         else:
-            numeric_value = float(item)
+            numeric_value = _require_finite_numeric(
+                item,
+                field_name=f"strategy param '{key}'",
+            )
         params[key] = numeric_value
     return params
 
@@ -213,7 +217,7 @@ def _parse_risk_overrides(value: Any, *, index: int, source: str) -> dict[str, f
             raise ValueError(
                 f"risk override '{key}' for strategy instance at index {index} in {source} must be numeric"
             )
-        numeric_value = float(item)
+        numeric_value = _require_finite_numeric(item, field_name=f"risk override '{key}'")
         if numeric_value < 0.0:
             raise ValueError(f"risk override '{key}' must be non-negative")
         if key == "max_gross_position" and numeric_value <= 0.0:
@@ -234,3 +238,10 @@ def _require_non_empty_string(
             f"strategy instance at index {index} in {source} must define a non-empty {field_name}"
         )
     return value.strip()
+
+
+def _require_finite_numeric(value: float | int, *, field_name: str) -> float:
+    numeric_value = float(value)
+    if not math.isfinite(numeric_value):
+        raise ValueError(f"{field_name} must be finite")
+    return numeric_value

--- a/tests/unit/test_strategy_instances.py
+++ b/tests/unit/test_strategy_instances.py
@@ -88,6 +88,19 @@ def test_parse_strategy_instance_specs_rejects_unknown_param_keys() -> None:
         )
 
 
+def test_parse_strategy_instance_specs_rejects_unknown_strategy_ids() -> None:
+    with pytest.raises(ValueError, match="unknown strategy_id 'unknown'"):
+        parse_strategy_instance_specs(
+            [
+                {
+                    "strategy_instance_id": "bad-strategy",
+                    "strategy_id": "unknown",
+                    "universe": ["BTC-PERP-INTX"],
+                }
+            ]
+        )
+
+
 def test_parse_strategy_instance_specs_rejects_boolean_numeric_values() -> None:
     with pytest.raises(ValueError, match="must be numeric"):
         parse_strategy_instance_specs(
@@ -133,6 +146,31 @@ def test_parse_strategy_instance_specs_rejects_fractional_lookback_and_zero_gros
                     "strategy_id": "momentum",
                     "universe": ["BTC-PERP-INTX"],
                     "risk_overrides": {"max_gross_position": 0.0},
+                }
+            ]
+        )
+
+
+def test_parse_strategy_instance_specs_rejects_non_finite_numeric_values() -> None:
+    with pytest.raises(ValueError, match="must be finite"):
+        parse_strategy_instance_specs(
+            [
+                {
+                    "strategy_instance_id": "nan-scale",
+                    "strategy_id": "momentum",
+                    "universe": ["BTC-PERP-INTX"],
+                    "strategy_params": {"signal_scale": float("nan")},
+                }
+            ]
+        )
+    with pytest.raises(ValueError, match="must be finite"):
+        parse_strategy_instance_specs(
+            [
+                {
+                    "strategy_instance_id": "inf-risk",
+                    "strategy_id": "momentum",
+                    "universe": ["BTC-PERP-INTX"],
+                    "risk_overrides": {"max_abs_position": float("inf")},
                 }
             ]
         )


### PR DESCRIPTION
## Summary
- add a research-only StrategyInstanceSpec contract for multi-sleeve work
- add JSON parsing and validation helpers for strategy instances
- document the strategy-instance schema and add coexistence/validation tests

## Testing
- PYTHONPATH=src python3 -m pytest tests/unit/test_strategy_instances.py
- PYTHONPATH=src python3 -m pytest
- python3 -m ruff check src/perpfut/strategy_instances.py tests/unit/test_strategy_instances.py

Closes #89