### PR TITLE
MS-7: add daily mean-variance portfolio optimizer

### DIFF
--- a/src/perpfut/portfolio_optimizer.py
+++ b/src/perpfut/portfolio_optimizer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 import math
 from typing import Any
 
@@ -101,7 +102,7 @@ def optimize_strategy_portfolio(
         [point.value for point in sleeve.daily_returns]
         for sleeve in sleeves
     ]
-    previous_weights = [0.0 for _ in sleeves]
+    current_holdings = [0.0 for _ in sleeves]
     cumulative_value = 1.0
     daily_gross_returns: list[SeriesPoint] = []
     daily_net_returns: list[SeriesPoint] = []
@@ -135,12 +136,19 @@ def optimize_strategy_portfolio(
                 ridge_penalty=optimizer_config.ridge_penalty,
             )
             raw_scores = _solve_linear_system(cov, mu)
+            if raw_scores is None:
+                raw_scores = list(mu)
+                constraint_status = "fallback_mean_only"
+            else:
+                constraint_status = "optimized"
             weights = _project_long_only_weights(
                 raw_scores,
                 max_weight=optimizer_config.max_strategy_weight,
             )
-            constraint_status = "optimized"
-        turnover = sum(abs(weight - previous_weight) for weight, previous_weight in zip(weights, previous_weights))
+        turnover = sum(
+            abs(weight - holding)
+            for weight, holding in zip(weights, current_holdings)
+        )
         gross_return = sum(
             weight * returns_matrix[strategy_index][day_index]
             for strategy_index, weight in enumerate(weights)
@@ -182,7 +190,13 @@ def optimize_strategy_portfolio(
         daily_net_returns.append(SeriesPoint(label=date_label, value=net_return))
         daily_turnover.append(SeriesPoint(label=date_label, value=turnover))
         cumulative_series.append(SeriesPoint(label=date_label, value=cumulative_value))
-        previous_weights = list(weights)
+        current_holdings = _drift_holdings(
+            weights,
+            day_returns=[
+                returns_matrix[strategy_index][day_index]
+                for strategy_index in range(len(sleeves))
+            ],
+        )
 
     return PortfolioOptimizationResult(
         strategy_instance_ids=strategy_instance_ids,
@@ -197,11 +211,24 @@ def optimize_strategy_portfolio(
 
 def _aligned_dates(sleeves: list[StrategySleeveReturnStream]) -> tuple[str, ...]:
     base_dates = [point.label for point in sleeves[0].daily_returns]
+    _validate_ordered_utc_day_labels(base_dates)
     for sleeve in sleeves[1:]:
         dates = [point.label for point in sleeve.daily_returns]
         if dates != base_dates:
             raise ValueError("sleeve return streams must share the same ordered daily date labels")
     return tuple(base_dates)
+
+
+def _validate_ordered_utc_day_labels(labels: list[str]) -> None:
+    parsed_dates: list[date] = []
+    for label in labels:
+        try:
+            parsed_dates.append(date.fromisoformat(label))
+        except ValueError as exc:
+            raise ValueError("sleeve return streams must use parseable YYYY-MM-DD daily labels") from exc
+    for previous, current in zip(parsed_dates, parsed_dates[1:]):
+        if current <= previous:
+            raise ValueError("sleeve return streams must use strictly increasing UTC day labels")
 
 
 def _estimate_covariance(
@@ -291,7 +318,7 @@ def _mean_vector(history: list[list[float]]) -> list[float]:
     ]
 
 
-def _solve_linear_system(matrix: list[list[float]], vector: list[float]) -> list[float]:
+def _solve_linear_system(matrix: list[list[float]], vector: list[float]) -> list[float] | None:
     size = len(vector)
     augmented = [
         [float(matrix[row][column]) for column in range(size)] + [float(vector[row])]
@@ -303,7 +330,7 @@ def _solve_linear_system(matrix: list[list[float]], vector: list[float]) -> list
             key=lambda row_index: abs(augmented[row_index][pivot_index]),
         )
         if math.isclose(augmented[pivot_row][pivot_index], 0.0, abs_tol=1e-12):
-            return [0.0 for _ in range(size)]
+            return None
         if pivot_row != pivot_index:
             augmented[pivot_index], augmented[pivot_row] = augmented[pivot_row], augmented[pivot_index]
         pivot_value = augmented[pivot_index][pivot_index]
@@ -316,6 +343,18 @@ def _solve_linear_system(matrix: list[list[float]], vector: list[float]) -> list
             for column in range(pivot_index, size + 1):
                 augmented[row][column] -= factor * augmented[pivot_index][column]
     return [augmented[row][size] for row in range(size)]
+
+
+def _drift_holdings(target_weights: list[float], *, day_returns: list[float]) -> list[float]:
+    gross_values = [
+        weight * (1.0 + day_return)
+        for weight, day_return in zip(target_weights, day_returns)
+    ]
+    cash_value = max(1.0 - sum(target_weights), 0.0)
+    total_value = cash_value + sum(gross_values)
+    if total_value <= 1e-12:
+        return [0.0 for _ in target_weights]
+    return [value / total_value for value in gross_values]
 
 
 def _parse_series_point(value: Any) -> SeriesPoint:

--- a/tests/integration/test_portfolio_optimizer_integration.py
+++ b/tests/integration/test_portfolio_optimizer_integration.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timedelta, timezone
+
+from perpfut.backtest_data import HistoricalDataset
+from perpfut.config import AppConfig
+from perpfut.domain import Candle
+from perpfut.portfolio_optimizer import (
+    PortfolioOptimizationConfig,
+    load_sleeve_return_stream,
+    optimize_strategy_portfolio,
+)
+from perpfut.sleeve_backtest import load_strategy_sleeve_analysis, run_strategy_sleeve
+from perpfut.strategy_instances import StrategyInstanceSpec
+
+
+def _build_cross_day_dataset() -> HistoricalDataset:
+    timestamps = [
+        datetime(2026, 3, 20, 23, 58, tzinfo=timezone.utc),
+        datetime(2026, 3, 20, 23, 59, tzinfo=timezone.utc),
+        datetime(2026, 3, 21, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 3, 21, 23, 58, tzinfo=timezone.utc),
+        datetime(2026, 3, 21, 23, 59, tzinfo=timezone.utc),
+        datetime(2026, 3, 22, 0, 0, tzinfo=timezone.utc),
+    ]
+    closes = [100.0, 102.0, 104.0, 105.0, 103.0, 101.0]
+    candles = tuple(
+        Candle(
+            start=timestamp,
+            low=close - 1.0,
+            high=close + 1.0,
+            open=close,
+            close=close,
+            volume=1_000.0,
+        )
+        for timestamp, close in zip(timestamps, closes)
+    )
+    return HistoricalDataset(
+        dataset_id="dataset-cross-day",
+        created_at=timestamps[0],
+        products=("BTC-PERP-INTX",),
+        start=timestamps[0],
+        end=timestamps[-1] + timedelta(minutes=1),
+        granularity="ONE_MINUTE",
+        candles_by_product={"BTC-PERP-INTX": candles},
+        fingerprint="cross-day-fingerprint",
+        source="coinbase",
+        version="1",
+    )
+
+
+def test_optimizer_uses_utc_daily_labels_from_real_sleeve_artifacts(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("LOOKBACK_CANDLES", "2")
+    monkeypatch.setenv("SIGNAL_SCALE", "150")
+    monkeypatch.setenv("REBALANCE_THRESHOLD", "0.0")
+    monkeypatch.setenv("MIN_TRADE_NOTIONAL_USDC", "0.0")
+    monkeypatch.setenv("SLIPPAGE_BPS", "0.0")
+    config = AppConfig.from_env()
+    sleeve = run_strategy_sleeve(
+        base_runs_dir=tmp_path,
+        dataset=_build_cross_day_dataset(),
+        config=config,
+        strategy_instance=StrategyInstanceSpec(
+            strategy_instance_id="mom-cross-day",
+            strategy_id="momentum",
+            universe=("BTC-PERP-INTX",),
+            strategy_params={"lookback_candles": 2, "signal_scale": 150.0},
+        ),
+    )
+
+    sleeve_payload = load_strategy_sleeve_analysis(sleeve.run_dir)
+    result = optimize_strategy_portfolio(
+        [load_sleeve_return_stream(sleeve_payload)],
+        config=PortfolioOptimizationConfig(
+            lookback_days=1,
+            max_strategy_weight=1.0,
+            turnover_cost_bps=0.0,
+        ),
+    )
+
+    assert [point["label"] for point in sleeve_payload["daily_returns"]] == [
+        "2026-03-21",
+        "2026-03-22",
+    ]
+    assert [point.label for point in result.daily_net_returns] == [
+        "2026-03-21",
+        "2026-03-22",
+    ]
+    assert [snapshot.date for snapshot in result.weight_history] == [
+        "2026-03-21",
+        "2026-03-22",
+    ]

--- a/tests/unit/test_portfolio_optimizer.py
+++ b/tests/unit/test_portfolio_optimizer.py
@@ -70,6 +70,26 @@ def test_optimizer_applies_turnover_costs_to_net_returns() -> None:
         assert net.value == pytest.approx(gross.value - (turnover.value * 0.001))
 
 
+def test_optimizer_turnover_uses_drifted_holdings_not_previous_targets() -> None:
+    sleeves = [
+        load_sleeve_return_stream(_sleeve("drift-a", [0.10, 1.0, 1.0])),
+        load_sleeve_return_stream(_sleeve("drift-b", [0.10, 0.0, 0.0])),
+    ]
+
+    result = optimize_strategy_portfolio(
+        sleeves,
+        config=PortfolioOptimizationConfig(
+            lookback_days=1,
+            max_strategy_weight=1.0,
+            turnover_cost_bps=0.0,
+        ),
+    )
+
+    assert result.weight_history[1].weights == pytest.approx({"drift-a": 0.5, "drift-b": 0.5})
+    assert result.weight_history[2].weights == pytest.approx({"drift-a": 1.0, "drift-b": 0.0})
+    assert result.daily_turnover[2].value == pytest.approx(2.0 / 3.0)
+
+
 def test_optimizer_handles_singular_covariance_with_shrinkage_and_ridge() -> None:
     sleeves = [
         load_sleeve_return_stream(_sleeve("identical-a", [0.01, 0.01, 0.01, 0.01])),
@@ -90,6 +110,27 @@ def test_optimizer_handles_singular_covariance_with_shrinkage_and_ridge() -> Non
     assert len(result.weight_history) == 4
     assert result.weight_history[-1].gross_weight <= 1.0 + 1e-12
     assert result.diagnostics[-1].constraint_status == "optimized"
+
+
+def test_optimizer_falls_back_to_mean_when_covariance_system_is_unsolved() -> None:
+    sleeves = [
+        load_sleeve_return_stream(_sleeve("identical-a", [0.01, 0.02, 0.03])),
+        load_sleeve_return_stream(_sleeve("identical-b", [0.01, 0.02, 0.03])),
+    ]
+
+    result = optimize_strategy_portfolio(
+        sleeves,
+        config=PortfolioOptimizationConfig(
+            lookback_days=2,
+            max_strategy_weight=0.6,
+            covariance_shrinkage=0.0,
+            ridge_penalty=0.0,
+            turnover_cost_bps=0.0,
+        ),
+    )
+
+    assert result.diagnostics[-1].constraint_status == "fallback_mean_only"
+    assert result.weight_history[-1].gross_weight > 0.0
 
 
 def test_optimizer_uses_ordered_utc_day_labels_from_sleeve_artifacts() -> None:
@@ -127,6 +168,63 @@ def test_optimizer_uses_ordered_utc_day_labels_from_sleeve_artifacts() -> None:
 
     assert [point.label for point in result.daily_net_returns] == ["2026-03-01", "2026-03-02"]
     assert [snapshot.date for snapshot in result.weight_history] == ["2026-03-01", "2026-03-02"]
+
+
+def test_optimizer_rejects_non_increasing_daily_labels() -> None:
+    sleeves = [
+        load_sleeve_return_stream(
+            {
+                "strategy_instance_id": "reverse-a",
+                "strategy_id": "momentum",
+                "dataset_id": "dataset-1",
+                "config_fingerprint": "a",
+                "daily_returns": [
+                    {"label": "2026-03-02", "value": 0.01},
+                    {"label": "2026-03-01", "value": 0.02},
+                ],
+            }
+        ),
+        load_sleeve_return_stream(
+            {
+                "strategy_instance_id": "reverse-b",
+                "strategy_id": "mean_reversion",
+                "dataset_id": "dataset-1",
+                "config_fingerprint": "b",
+                "daily_returns": [
+                    {"label": "2026-03-02", "value": 0.03},
+                    {"label": "2026-03-01", "value": -0.01},
+                ],
+            }
+        ),
+    ]
+
+    with pytest.raises(ValueError, match="strictly increasing UTC day labels"):
+        optimize_strategy_portfolio(
+            sleeves,
+            config=PortfolioOptimizationConfig(lookback_days=1, turnover_cost_bps=0.0),
+        )
+
+
+def test_optimizer_rejects_unparseable_daily_labels() -> None:
+    sleeves = [
+        load_sleeve_return_stream(
+            {
+                "strategy_instance_id": "bad-label-a",
+                "strategy_id": "momentum",
+                "dataset_id": "dataset-1",
+                "config_fingerprint": "a",
+                "daily_returns": [
+                    {"label": "03/01/2026", "value": 0.01},
+                ],
+            }
+        )
+    ]
+
+    with pytest.raises(ValueError, match="parseable YYYY-MM-DD daily labels"):
+        optimize_strategy_portfolio(
+            sleeves,
+            config=PortfolioOptimizationConfig(lookback_days=1, turnover_cost_bps=0.0),
+        )
 
 
 def test_load_sleeve_return_stream_validates_payload() -> None:


### PR DESCRIPTION
## Summary
- add a daily long-only mean-variance optimizer over cached sleeve return streams
- apply covariance shrinkage, ridge regularization, max-weight caps, and turnover costs
- add unit coverage for singular covariance, UTC day alignment, and constraint behavior

## Testing
- PYTHONPATH=src python3 -m pytest tests/unit/test_portfolio_optimizer.py
- PYTHONPATH=src python3 -m pytest
- python3 -m ruff check src/perpfut/portfolio_optimizer.py tests/unit/test_portfolio_optimizer.py

Closes #91