### PR TITLE
Complete MS-12 research console docs and coverage

### DIFF
--- a/apps/web/components/backtests-shell.test.tsx
+++ b/apps/web/components/backtests-shell.test.tsx
@@ -1077,6 +1077,113 @@ describe("BacktestsShell", () => {
     expect(await screen.findByText("sleeve comparison unavailable")).toBeInTheDocument();
     expect(await screen.findByText("optimizer comparison unavailable")).toBeInTheDocument();
   });
+
+  it("renders an isolated optimizer list error state when portfolio runs fail", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path === "/datasets") {
+        return {
+          items: [
+            {
+              datasetId: "dataset-1",
+              createdAt: "2026-03-22T05:00:00Z",
+              fingerprint: "fingerprint-123456",
+              source: "coinbase",
+              version: "1",
+              products: ["BTC-PERP-INTX"],
+              start: "2026-03-20T12:00:00+00:00",
+              end: "2026-03-21T12:00:00+00:00",
+              granularity: "ONE_MINUTE",
+              candleCounts: { "BTC-PERP-INTX": 1440 },
+            },
+          ],
+          count: 1,
+        };
+      }
+      if (path === "/backtests") {
+        return { items: [], count: 0, active_job: null, latest_job: null };
+      }
+      if (path === "/backtest-suites") {
+        return { items: [], count: 0, active_job: null, latest_job: null };
+      }
+      if (path === "/portfolio-runs" || path === "/portfolio-runs?datasetId=dataset-1") {
+        throw new ApiError("portfolio runs unavailable", 500);
+      }
+      if (path === "/portfolio-run-comparisons" || path === "/portfolio-run-comparisons?datasetId=dataset-1") {
+        return defaultPortfolioComparisonResponse;
+      }
+      if (path === "/sleeves" || path === "/sleeves?datasetId=dataset-1") {
+        return defaultSleeveListResponse;
+      }
+      if (path === "/sleeve-comparisons" || path === "/sleeve-comparisons?datasetId=dataset-1") {
+        return defaultSleeveComparisonResponse;
+      }
+      if (path === "/sleeves/sleeve-run-1") {
+        return defaultSleeveDetailResponse;
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderBacktestsShell();
+
+    await waitFor(() => expect(mockedFetchJson).toHaveBeenCalledWith("/portfolio-runs?datasetId=dataset-1"));
+    expect(await screen.findByText("portfolio runs unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Strategy sleeve runs")).toBeInTheDocument();
+    expect(screen.getByText("Selected suite, sleeve, and optimizer rankings")).toBeInTheDocument();
+  });
+
+  it("renders optimizer detail errors without hiding the optimizer run list", async () => {
+    mockedFetchJson.mockImplementation(async (path: string) => {
+      if (path === "/datasets") {
+        return {
+          items: [
+            {
+              datasetId: "dataset-1",
+              createdAt: "2026-03-22T05:00:00Z",
+              fingerprint: "fingerprint-123456",
+              source: "coinbase",
+              version: "1",
+              products: ["BTC-PERP-INTX"],
+              start: "2026-03-20T12:00:00+00:00",
+              end: "2026-03-21T12:00:00+00:00",
+              granularity: "ONE_MINUTE",
+              candleCounts: { "BTC-PERP-INTX": 1440 },
+            },
+          ],
+          count: 1,
+        };
+      }
+      if (path === "/backtests") {
+        return { items: [], count: 0, active_job: null, latest_job: null };
+      }
+      if (path === "/backtest-suites") {
+        return { items: [], count: 0, active_job: null, latest_job: null };
+      }
+      if (path === "/portfolio-runs" || path === "/portfolio-runs?datasetId=dataset-1") {
+        return defaultPortfolioRunsResponse;
+      }
+      if (path === "/portfolio-run-comparisons" || path === "/portfolio-run-comparisons?datasetId=dataset-1") {
+        return defaultPortfolioComparisonResponse;
+      }
+      if (path === "/portfolio-runs/portfolio-run-1") {
+        throw new ApiError("portfolio detail unavailable", 500);
+      }
+      if (path === "/sleeves" || path === "/sleeves?datasetId=dataset-1") {
+        return defaultSleeveListResponse;
+      }
+      if (path === "/sleeve-comparisons" || path === "/sleeve-comparisons?datasetId=dataset-1") {
+        return defaultSleeveComparisonResponse;
+      }
+      if (path === "/sleeves/sleeve-run-1") {
+        return defaultSleeveDetailResponse;
+      }
+      throw new Error(`unexpected path ${path}`);
+    });
+
+    renderBacktestsShell();
+
+    expect(await screen.findByText("portfolio detail unavailable")).toBeInTheDocument();
+    expect(screen.getAllByText("portfolio-run-1").length).toBeGreaterThan(0);
+  });
 });
 
 describe("BacktestRunShell", () => {

--- a/docs/backtesting.md
+++ b/docs/backtesting.md
@@ -1,29 +1,43 @@
 # Backtesting
 
-`perpfut` now has a historical backtesting system that reuses the same
-strategy registry and signal code used by paper and live execution. The
-backtest runner does not introduce a separate strategy API; it synthesizes the
-same `MarketSnapshot` inputs that production strategies already consume.
+`perpfut` now has a historical research stack that reuses the same strategy
+registry and signal code used by paper and live execution. The backtest runner
+does not introduce a separate strategy API; it synthesizes the same
+`MarketSnapshot` inputs that production strategies already consume.
 
 ## Design
 
-Backtests are bar-based and file-backed.
+The historical stack is bar-based and file-backed.
 
 - Historical source: Coinbase candle history only
 - Strategy inputs: the same per-asset `MarketSnapshot` used in paper/live
 - Signal timing: bar close at time `t`
 - Fill timing: next bar open at time `t+1`
-- Portfolio model: shared-capital, multi-asset allocator for backtests only
 - Output contract: the same canonical analysis payload used by `analyze`,
   operator API responses, and experiment ranking
 
-The backtest portfolio layer sits above per-asset signals:
+The research stack is now split into three layers:
+
+1. `dataset`: fetch and cache aligned OHLCV history once
+2. `sleeve`: run one strategy instance over one cached dataset and persist
+   reusable sleeve outputs
+3. `portfolio`: combine cached sleeve return streams with the daily
+   mean-variance optimizer
+
+The minute-bar execution layer still sits above the same per-asset signals:
 
 1. Build aligned candle snapshots across all selected products.
 2. Evaluate each strategy per asset with the standard registry.
 3. Convert normalized targets into shared-capital portfolio allocations.
 4. Fill rebalances at the next bar open using the existing simulation model.
 5. Persist run artifacts and `analysis.json`.
+
+The optimizer layer is intentionally separate from minute-bar execution:
+
+1. Load cached sleeve artifacts for one dataset.
+2. Build daily sleeve return, turnover, and attribution series.
+3. Rebalance daily across sleeves with long-only weights and cash residual.
+4. Persist optimizer artifacts, weights, diagnostics, and portfolio analysis.
 
 ## CLI
 
@@ -44,6 +58,9 @@ Inspect cached datasets:
 python3 -m perpfut dataset list
 python3 -m perpfut dataset show --dataset-id <dataset_id>
 ```
+
+The fastest iterative workflow is to build once, then reuse `--dataset-id` in
+all later backtests, sleeve studies, and optimizer runs.
 
 Launch a backtest suite from a dataset definition:
 
@@ -80,20 +97,45 @@ python3 -m perpfut backtest show --run-id <run_id>
 python3 -m perpfut backtest compare --suite-id <suite_id>
 ```
 
+Run research-only optimizer portfolio studies:
+
+```bash
+python3 -m perpfut portfolio run \
+  --dataset-id <dataset_id> \
+  --strategy-specs strategy_specs.json
+```
+
+Inspect optimizer portfolio outputs:
+
+```bash
+python3 -m perpfut portfolio list
+python3 -m perpfut portfolio show --run-id <run_id>
+python3 -m perpfut portfolio compare --dataset-id <dataset_id>
+```
+
+`strategy_specs.json` uses the research-only `StrategyInstanceSpec` schema from
+[`docs/strategy-research.md`](./strategy-research.md). This lets you evaluate
+multiple differently parameterized sleeves without changing the production
+strategy registry or paper/live configuration.
+
 Important behavior:
 
 - invalid strategy IDs are rejected before any historical data fetches occur
-- identical dataset requests reuse the same cached dataset id instead of refetching Coinbase
-- `dataset build`/`dataset show` surface clean CLI exits for invalid ranges or missing datasets
+- identical dataset requests reuse the same cached dataset id instead of
+  refetching Coinbase
+- `dataset build` and `dataset show` surface clean CLI exits for invalid ranges
+  or missing datasets
 - backtest suites require at least one executable cycle
 - `backtest show` and `backtest compare` surface clean CLI exits for missing or
   invalid artifacts
 - `backtest list` skips malformed suite manifests and returns the remaining
   readable suites
+- optimizer runs reuse persisted sleeve artifacts and do not refetch Coinbase
+  once the dataset and sleeves already exist
 
 ## Artifact Layout
 
-Backtest artifacts live under `runs/backtests/`.
+Historical research artifacts live under `runs/backtests/`.
 
 ```text
 runs/
@@ -102,7 +144,7 @@ runs/
     │   └── <dataset_id>/
     │       ├── manifest.json
     │       ├── BTC-PERP-INTX.json
-    │       └── ETH-PERP-INTX.json
+    │       ├── ETH-PERP-INTX.json
     │       └── .cache/
     │           └── aligned_windows_lookback_<n>_<product_hash>.json
     ├── runs/
@@ -113,6 +155,24 @@ runs/
     │       ├── fills.ndjson
     │       ├── positions.ndjson
     │       └── state.json
+    ├── sleeves/
+    │   └── <run_id>/
+    │       ├── manifest.json
+    │       ├── analysis.json
+    │       ├── sleeve_analysis.json
+    │       ├── events.ndjson
+    │       ├── fills.ndjson
+    │       ├── positions.ndjson
+    │       └── state.json
+    ├── portfolio-runs/
+    │   └── <run_id>/
+    │       ├── manifest.json
+    │       ├── config.json
+    │       ├── state.json
+    │       ├── analysis.json
+    │       ├── weights.ndjson
+    │       ├── diagnostics.ndjson
+    │       └── contributions.json
     ├── suites/
     │   └── <suite_id>/
     │       └── manifest.json
@@ -127,9 +187,16 @@ runs/
 Artifacts mean:
 
 - `datasets/<dataset_id>/`: persisted historical candle inputs for reuse
-- `datasets/<dataset_id>/manifest.json`: dataset identity, fingerprint, source, coverage, and candle counts
-- `datasets/<dataset_id>/.cache/`: internal aligned-window caches used to accelerate repeated runs
+- `datasets/<dataset_id>/manifest.json`: dataset identity, fingerprint, source,
+  coverage, and candle counts
+- `datasets/<dataset_id>/.cache/`: internal aligned-window caches used to
+  accelerate repeated runs
 - `runs/<run_id>/`: one strategy run over one dataset
+- `sleeves/<run_id>/`: one research sleeve with reusable daily return,
+  exposure, turnover, and per-asset attribution outputs embedded in
+  `analysis.json` and `sleeve_analysis.json`
+- `portfolio-runs/<run_id>/`: one optimizer portfolio run over cached sleeve
+  outputs
 - `suites/<suite_id>/`: suite manifest linking multiple strategy runs
 - `control/`: local API job orchestration metadata and logs
 
@@ -140,14 +207,37 @@ Backtest run events are portfolio-oriented:
 - `positions.ndjson` stores the aggregate portfolio and per-asset positions
 - `state.json` is the latest portfolio checkpoint
 
+Sleeve and optimizer artifacts are research-oriented:
+
+- `sleeve_analysis.json`: sleeve daily return, turnover, drawdown, exposure,
+  and per-asset contribution series
+- `weights.ndjson`: optimizer weights by strategy instance and day
+- `diagnostics.ndjson`: optimizer expected returns, covariance snapshot, and
+  constraint status for each rebalance date
+- `contributions.json`: per-strategy contribution totals and daily series
+
+## Research Workflow
+
+The canonical fast-iteration loop is:
+
+1. Build or reuse a dataset once.
+2. Run one or more backtest suites to validate raw strategy behavior.
+3. Convert promising strategy ideas into explicit `StrategyInstanceSpec`
+   sleeves.
+4. Run optimizer portfolio research across cached sleeve outputs.
+5. Compare portfolio runs by dataset, Sharpe, drawdown, turnover, and lineup.
+
+That flow is documented end-to-end in
+[`docs/research-workflow.md`](./research-workflow.md).
+
 ## Operator API
 
-Backtest routes are rooted at `/api`.
+Historical research routes are rooted at `/api`.
 
-- `GET /api/backtests`
 - `GET /api/datasets`
 - `POST /api/datasets`
 - `GET /api/datasets/{datasetId}`
+- `GET /api/backtests`
 - `POST /api/backtests`
 - `GET /api/backtests/{runId}`
 - `GET /api/backtests/{runId}/analysis`
@@ -156,6 +246,14 @@ Backtest routes are rooted at `/api`.
 - `GET /api/backtests/{runId}/fills?limit=`
 - `GET /api/backtest-suites`
 - `GET /api/backtest-suites/{suiteId}`
+- `GET /api/sleeves`
+- `GET /api/sleeve-comparisons`
+- `GET /api/sleeves/{runId}`
+- `GET /api/portfolio-runs`
+- `POST /api/portfolio-runs`
+- `GET /api/portfolio-runs/{runId}`
+- `GET /api/portfolio-runs/{runId}/analysis`
+- `GET /api/portfolio-run-comparisons`
 
 `POST /api/datasets` is synchronous in v1: it builds or reuses a cached dataset
 and returns the dataset summary in the same response.
@@ -163,31 +261,6 @@ and returns the dataset summary in the same response.
 `POST /api/backtests` launches one local background backtest job at a time and
 returns job metadata. Job status is surfaced through the `active_job` and
 `latest_job` fields on the list routes.
-
-Example dataset build request:
-
-```json
-{
-  "productIds": ["BTC-PERP-INTX", "ETH-PERP-INTX"],
-  "start": "2026-03-20T00:00:00+00:00",
-  "end": "2026-03-21T00:00:00+00:00",
-  "granularity": "ONE_MINUTE"
-}
-```
-
-Example request:
-
-```json
-{
-  "datasetId": "20260322T120000000000Z",
-  "strategyIds": ["momentum", "mean_reversion"],
-  "startingCollateralUsdc": 10000,
-  "maxAbsPosition": 0.5,
-  "maxGrossPosition": 1.0,
-  "maxLeverage": 2.0,
-  "slippageBps": 3
-}
-```
 
 The list endpoints are intentionally split:
 
@@ -197,6 +270,13 @@ The list endpoints are intentionally split:
 - `/api/backtest-suites` returns completed suite manifests, the current
   `active_job`, and the most recent terminal `latest_job`
 - `/api/backtest-suites/{suiteId}` returns the ranked suite comparison payload
+- `/api/sleeves` returns strategy sleeve summaries, optionally filtered by
+  `datasetId`
+- `/api/sleeve-comparisons` returns the sleeve leaderboard for one dataset
+- `/api/portfolio-runs` returns optimizer portfolio run summaries, optionally
+  filtered by `datasetId`
+- `/api/portfolio-run-comparisons` returns the optimizer leaderboard for one
+  dataset
 
 ## Constraints
 
@@ -205,6 +285,9 @@ This is still a bar-based MVP.
 - No intrabar simulation
 - No order-book replay
 - No funding-rate modeling inside the backtest engine
-- No database; datasets, runs, suites, and jobs are all artifact-backed
-- Multi-asset allocation exists only in backtests for now; live and paper remain
-  single-asset execution paths
+- No database; datasets, runs, suites, sleeves, portfolio runs, and jobs are
+  all artifact-backed
+- Multi-asset allocation exists only in backtests for now; live and paper
+  remain single-asset execution paths
+- Multi-strategy optimizer research is still research-only; there is no
+  multi-strategy paper/live allocator yet

--- a/docs/operator-api.md
+++ b/docs/operator-api.md
@@ -1,9 +1,11 @@
 # Operator API
 
-`perpfut` exposes a local-only operator API for the Next.js dashboard.
+`perpfut` exposes a local-only operator API for the Next.js dashboard and the
+historical research console.
 
-The current dashboard is monitor-first. Read routes are already consumed by the
-UI, while the paper-run control routes are available for the next frontend step.
+The API is artifact-backed. It does not maintain an in-memory trading or
+research state model for the UI; instead it reads the newest valid files under
+`runs/` and `runs/backtests/`.
 
 ## Runtime
 
@@ -47,6 +49,13 @@ All routes are rooted at `/api`.
 - `GET /api/backtests/{runId}/positions?limit=`
 - `GET /api/backtest-suites`
 - `GET /api/backtest-suites/{suiteId}`
+- `GET /api/sleeves`
+- `GET /api/sleeve-comparisons`
+- `GET /api/sleeves/{runId}`
+- `GET /api/portfolio-runs`
+- `GET /api/portfolio-run-comparisons`
+- `GET /api/portfolio-runs/{runId}`
+- `GET /api/portfolio-runs/{runId}/analysis`
 
 ### Control routes
 
@@ -54,8 +63,11 @@ All routes are rooted at `/api`.
 - `POST /api/paper-runs/stop`
 - `POST /api/datasets`
 - `POST /api/backtests`
+- `POST /api/portfolio-runs`
 
-Start requests accept:
+## Paper Requests
+
+Paper-run start requests accept:
 
 ```json
 {
@@ -71,6 +83,8 @@ Start requests accept:
 
 The service allows only one active paper run at a time.
 
+## Dataset Requests
+
 Dataset build requests accept:
 
 ```json
@@ -84,6 +98,20 @@ Dataset build requests accept:
 
 Dataset builds are synchronous in v1 and return the dataset summary directly.
 Requests must use timezone-aware timestamps.
+
+The returned dataset summary is the cache anchor for all later research:
+
+- `datasetId`
+- `fingerprint`
+- `source`
+- `version`
+- `products`
+- `start`
+- `end`
+- `granularity`
+- `candleCounts`
+
+## Backtest Requests
 
 Backtest launch requests accept either a cached dataset id:
 
@@ -118,15 +146,112 @@ or an inline historical range:
 
 The service currently allows only one active backtest job at a time.
 
-### Dashboard Overview Shape
+Backtest job progress is surfaced through `active_job` and `latest_job` on the
+list routes. The UI should treat these as the canonical status source for:
 
-`GET /api/dashboard/overview` now returns:
+- current phase
+- phase message
+- completed runs versus total runs
+- progress percentage
+- elapsed seconds
+- ETA seconds
+- terminal error, if any
+
+## Research Stack Requests
+
+The research stack adds two higher-level API domains on top of datasets and
+backtests:
+
+1. `sleeves`: strategy-instance studies over one cached dataset
+2. `portfolio-runs`: optimizer studies over cached sleeve outputs
+
+### Sleeve routes
+
+- `GET /api/sleeves`
+- `GET /api/sleeves?datasetId=<dataset_id>`
+- `GET /api/sleeve-comparisons`
+- `GET /api/sleeve-comparisons?datasetId=<dataset_id>`
+- `GET /api/sleeves/{runId}`
+
+Sleeve list responses are newest-first summaries keyed by dataset and strategy
+instance. Sleeve detail responses include:
+
+- `manifest`
+- `state`
+- canonical `analysis`
+- `sleeve_analysis` with per-asset contribution totals
+
+### Portfolio optimizer routes
+
+- `GET /api/portfolio-runs`
+- `GET /api/portfolio-runs?datasetId=<dataset_id>`
+- `GET /api/portfolio-run-comparisons`
+- `GET /api/portfolio-run-comparisons?datasetId=<dataset_id>`
+- `GET /api/portfolio-runs/{runId}`
+- `GET /api/portfolio-runs/{runId}/analysis`
+- `POST /api/portfolio-runs`
+
+`POST /api/portfolio-runs` accepts:
+
+```json
+{
+  "datasetId": "20260322T120000000000Z",
+  "startingCapitalUsdc": 10000,
+  "lookbackDays": 60,
+  "maxStrategyWeight": 0.4,
+  "covarianceShrinkage": 0.1,
+  "ridgePenalty": 0.001,
+  "turnoverCostBps": 2.0,
+  "strategyInstances": [
+    {
+      "strategyInstanceId": "mom-fast",
+      "strategyId": "momentum",
+      "universe": ["BTC-PERP-INTX", "ETH-PERP-INTX"],
+      "strategyParams": {
+        "lookback_candles": 10,
+        "signal_scale": 20.0
+      },
+      "riskOverrides": {
+        "max_abs_position": 0.3
+      }
+    }
+  ]
+}
+```
+
+The top-level API request uses camelCase field names. The nested
+`strategyParams` and `riskOverrides` objects keep the snake_case keys from the
+research-only `StrategyInstanceSpec` contract.
+
+Portfolio detail responses include:
+
+- `manifest`
+- `config`
+- `state`
+- `analysis`
+- `weights`
+- `diagnostics`
+- `contributions`
+
+These routes are what power the frontend optimizer views for:
+
+- run list and selection
+- Sharpe, return, drawdown, and turnover summaries
+- daily weight history
+- per-strategy contribution attribution
+
+## Dashboard Overview Shape
+
+`GET /api/dashboard/overview` returns:
 
 - `latest_run`: newest readable run matching the requested mode
 - `latest_state`: raw latest checkpoint payload for the run
-- `latest_decision`: normalized operator-facing decision summary derived from the latest checkpoint
-- `latest_analysis`: canonical performance summary derived from the run artifacts
-- `recent_events`, `recent_fills`, `recent_positions`: newest-first artifact rows
+- `latest_decision`: normalized operator-facing decision summary derived from
+  the latest checkpoint
+- `latest_analysis`: canonical performance summary derived from the run
+  artifacts
+- `recent_events`, `recent_fills`, `recent_positions`: newest-first artifact
+  rows
 
 `latest_decision` contains:
 
@@ -142,41 +267,34 @@ The service currently allows only one active backtest job at a time.
 
 The nested decision objects use the same field names written into run artifacts.
 
-`GET /api/runs/{runId}/analysis` returns the same canonical analysis payload used by
-`latest_analysis`, including:
+`GET /api/runs/{runId}/analysis` returns the same canonical analysis payload
+used by `latest_analysis`, including:
 
 - run identity: `run_id`, `mode`, `product_id`, `strategy_id`
 - timing: `started_at`, `ended_at`, `cycle_count`
-- pnl and return: `starting_equity_usdc`, `ending_equity_usdc`, `realized_pnl_usdc`, `unrealized_pnl_usdc`, `total_pnl_usdc`, `total_return_pct`
-- risk and activity: `max_drawdown_usdc`, `max_drawdown_pct`, `turnover_usdc`, `fill_count`, `trade_count`
-- exposure and decisions: `avg_abs_exposure_pct`, `max_abs_exposure_pct`, `decision_counts`
+- pnl and return: `starting_equity_usdc`, `ending_equity_usdc`,
+  `realized_pnl_usdc`, `unrealized_pnl_usdc`, `total_pnl_usdc`,
+  `total_return_pct`
+- risk and activity: `max_drawdown_usdc`, `max_drawdown_pct`, `turnover_usdc`,
+  `fill_count`, `trade_count`
+- exposure and decisions: `avg_abs_exposure_pct`, `max_abs_exposure_pct`,
+  `decision_counts`
 - chart series: `equity_series`, `drawdown_series`, `exposure_series`
 
-### Backtest API Shape
+## Backtest and Research Response Shape
 
 `GET /api/datasets` returns:
 
-- `items`: newest-first cached datasets with fingerprint, source, coverage, and candle counts
+- `items`: newest-first cached datasets with fingerprint, source, coverage, and
+  candle counts
 - `count`
-
-`GET /api/datasets/{datasetId}` returns:
-
-- dataset identity: `datasetId`, `createdAt`, `fingerprint`, `source`, `version`
-- coverage: `products`, `start`, `end`, `granularity`
-- counts: `candleCounts`
 
 `GET /api/backtests` returns:
 
 - `items`: newest-first completed backtest runs with canonical metrics
-- `count`: number of returned runs
+- `count`
 - `active_job`: the current in-flight backtest job, or `null`
 - `latest_job`: the most recent terminal backtest job, or `null`
-
-`GET /api/backtests/{runId}` returns:
-
-- `manifest`
-- `state`
-- `analysis`
 
 `GET /api/backtest-suites` returns:
 
@@ -190,7 +308,23 @@ The nested decision objects use the same field names written into run artifacts.
 - suite identity: `suite_id`, `created_at`, `dataset_id`
 - suite scope: `products`, `strategies`, `run_ids`
 - ranking metadata: `ranking_policy`
+- date coverage: `date_range_start`, `date_range_end`
+- summary risk metric: `sharpe_ratio`
 - ranked items with canonical performance metrics per run
+
+`GET /api/sleeve-comparisons` returns:
+
+- `dataset_id`
+- `ranking_policy`
+- ranked sleeve items with return, drawdown, turnover, exposure, and per-asset
+  contribution totals
+
+`GET /api/portfolio-run-comparisons` returns:
+
+- `dataset_id`
+- `ranking_policy`
+- ranked optimizer runs with Sharpe, return, drawdown, turnover, gross-weight,
+  and strategy-lineup metadata
 
 ## Design Notes
 
@@ -199,10 +333,12 @@ The nested decision objects use the same field names written into run artifacts.
 - Paper runs are launched by spawning `python3 -m perpfut paper ...`.
 - Dataset builds are handled synchronously inside the API process in v1.
 - Backtest suites are launched by spawning `python3 -m perpfut backtest run ...`.
+- Optimizer portfolio runs are executed inline inside the API process in v1.
 - Stop requests send `SIGTERM`, then escalate to `SIGKILL` after 5 seconds.
 - Process metadata writes are atomic and protected by a local control lock.
 - Backtest jobs persist status to `runs/backtests/control/jobs/<job_id>.json`.
-- Live mode remains read-only in the UI. There are no live-trading control routes.
+- Live mode remains read-only in the UI. There are no live-trading control
+  routes.
 
 ## Frontend Expectations
 
@@ -210,6 +346,9 @@ The nested decision objects use the same field names written into run artifacts.
 - Treat missing latest runs as an empty state, not an error.
 - Treat `409` on `POST /api/paper-runs` as "paper run already active".
 - Treat `409` on `POST /api/backtests` as "backtest job already active".
-- Treat `500` on control routes as operator-visible failures that should not be retried blindly.
-- Use `/api/dashboard/overview` for the landing page and `/api/runs/{runId}/...` for drill-down views.
-- Use `/api/backtests` and `/api/backtest-suites/...` for the backtest console.
+- Treat `500` on control routes as operator-visible failures that should not be
+  retried blindly.
+- Use `/api/dashboard/overview` for the landing page and `/api/runs/{runId}/...`
+  for drill-down views.
+- Use `/api/datasets`, `/api/backtests`, `/api/backtest-suites`,
+  `/api/sleeves`, and `/api/portfolio-runs` for the research console.

--- a/docs/research-workflow.md
+++ b/docs/research-workflow.md
@@ -1,0 +1,212 @@
+# Research Workflow
+
+This document describes the intended fast-iteration loop for the historical
+research stack.
+
+The goal is to avoid repeatedly downloading the same market data or rerunning
+minute-bar execution when you only want to compare sleeve lineups or optimizer
+settings.
+
+## The Three Layers
+
+### 1. Dataset
+
+Datasets are the reusable historical market-data base.
+
+They are fingerprinted by:
+
+- source
+- product set
+- start timestamp
+- end timestamp
+- granularity
+- dataset version
+
+Build or reuse one dataset first:
+
+```bash
+python3 -m perpfut dataset build \
+  --product-id BTC-PERP-INTX \
+  --product-id ETH-PERP-INTX \
+  --start 2026-01-01T00:00:00+00:00 \
+  --end 2026-03-01T00:00:00+00:00 \
+  --granularity ONE_MINUTE
+```
+
+Then inspect it:
+
+```bash
+python3 -m perpfut dataset list
+python3 -m perpfut dataset show --dataset-id <dataset_id>
+```
+
+Use that `dataset_id` everywhere else.
+
+### 2. Sleeve
+
+A sleeve is one research strategy instance over one cached dataset.
+
+Sleeves are defined by `StrategyInstanceSpec`, which adds:
+
+- stable `strategy_instance_id`
+- existing `strategy_id`
+- asset universe
+- strategy params
+- per-sleeve risk overrides
+
+This is the layer where you compare multiple variants of the same production
+strategy code without changing the production execution interfaces.
+
+Strategy instance specs live in JSON. See
+[`docs/strategy-research.md`](./strategy-research.md) for the schema.
+
+### 3. Portfolio Optimizer
+
+The optimizer sits above sleeves and consumes cached sleeve daily return
+streams.
+
+V1 behavior:
+
+- daily rebalance
+- long-only strategy weights
+- cash residual allowed
+- max weight per strategy
+- rolling lookback on sleeve daily returns
+- shrinkage and ridge regularization for covariance stability
+
+This means optimizer experiments are much faster than rerunning raw minute-bar
+backtests for every lineup change.
+
+## Recommended Loop
+
+1. Build or reuse a dataset.
+2. Run a backtest suite to sanity-check strategy behavior on that dataset.
+3. Promote the promising strategy ideas into explicit sleeve specs.
+4. Run one or more optimizer portfolios on top of those cached sleeves.
+5. Compare optimizer runs on Sharpe, drawdown, turnover, and contribution mix.
+
+## CLI Walkthrough
+
+### Build the dataset once
+
+```bash
+python3 -m perpfut dataset build \
+  --product-id BTC-PERP-INTX \
+  --product-id ETH-PERP-INTX \
+  --start 2026-01-01T00:00:00+00:00 \
+  --end 2026-03-01T00:00:00+00:00
+```
+
+### Validate raw strategy behavior
+
+```bash
+python3 -m perpfut backtest run \
+  --dataset-id <dataset_id> \
+  --strategy-id momentum \
+  --strategy-id mean_reversion
+```
+
+### Define sleeve specs
+
+Example `strategy_specs.json`:
+
+```json
+[
+  {
+    "strategy_instance_id": "mom-fast",
+    "strategy_id": "momentum",
+    "universe": ["BTC-PERP-INTX", "ETH-PERP-INTX"],
+    "strategy_params": {
+      "lookback_candles": 10,
+      "signal_scale": 18.0
+    },
+    "risk_overrides": {
+      "max_abs_position": 0.3
+    }
+  },
+  {
+    "strategy_instance_id": "mr-slow",
+    "strategy_id": "mean_reversion",
+    "universe": ["BTC-PERP-INTX", "ETH-PERP-INTX"],
+    "strategy_params": {
+      "lookback_candles": 40,
+      "signal_scale": 8.0
+    },
+    "risk_overrides": {
+      "max_abs_position": 0.2
+    }
+  }
+]
+```
+
+### Run optimizer research
+
+```bash
+python3 -m perpfut portfolio run \
+  --dataset-id <dataset_id> \
+  --strategy-specs strategy_specs.json
+```
+
+### Compare optimizer runs
+
+```bash
+python3 -m perpfut portfolio list --dataset-id <dataset_id>
+python3 -m perpfut portfolio compare --dataset-id <dataset_id>
+python3 -m perpfut portfolio show --run-id <run_id>
+```
+
+## Frontend Walkthrough
+
+The backtests console now has three research sections:
+
+- `Datasets`
+- `Strategy Sleeves`
+- `Portfolio Optimizer`
+
+Recommended UI flow:
+
+1. Build or select a cached dataset in `Datasets`.
+2. Use that dataset context to inspect sleeves in `Strategy Sleeves`.
+3. Inspect optimizer runs and rankings in `Portfolio Optimizer`.
+4. Open a backtest run detail page when you need full minute-bar execution
+   context.
+
+The selected dataset acts as the scoping key for sleeves and optimizer runs in
+the UI.
+
+## Artifact Lineage
+
+The lineage should always be read as:
+
+```text
+dataset -> backtest run / sleeve -> portfolio optimizer run
+```
+
+More concretely:
+
+- one `dataset_id` can feed many backtest suites
+- one `dataset_id` can feed many sleeves
+- one optimizer run references one dataset and a lineup of sleeves
+
+When something looks wrong in optimizer results, debug in this order:
+
+1. dataset coverage and candle counts
+2. sleeve-level return and attribution behavior
+3. optimizer weights and diagnostics
+
+## When To Rebuild Data
+
+Rebuild or build a new dataset when:
+
+- the product set changes
+- the time window changes
+- the granularity changes
+- the dataset schema/version changes
+
+Do not rebuild when:
+
+- you are only changing sleeve parameters
+- you are only changing optimizer lookback or constraints
+- you are only comparing lineups on the same historical range
+
+That is the core speed principle in this stack.


### PR DESCRIPTION
Closes #96

## Summary
- add optimizer-focused frontend coverage for isolated list/detail failure states
- refresh backtesting and operator API docs for datasets, sleeves, and portfolio runs
- add an end-to-end research workflow document covering dataset -> sleeve -> optimizer lineage

## Validation
- PYTHONPATH=src python3 -m pytest
- python3 -m ruff check src/perpfut tests
- cd apps/web && npm run test
- cd apps/web && npm run build