### PR TITLE
Fix MS-6 sleeve drawdown artifact fidelity

### DIFF
--- a/src/perpfut/sleeve_backtest.py
+++ b/src/perpfut/sleeve_backtest.py
@@ -235,6 +235,7 @@ def _aggregate_daily_metrics(
 ) -> dict[str, Any]:
     daily_rows: dict[str, dict[str, Any]] = {}
     previous_asset_pnl = {product_id: 0.0 for product_id in universe}
+    running_peak_equity = starting_equity_usdc
     for cycle in results:
         day = _day_key(cycle.timestamp)
         row = daily_rows.setdefault(
@@ -244,9 +245,15 @@ def _aggregate_daily_metrics(
                 "turnover_usdc": 0.0,
                 "exposure_points": [],
                 "asset_pnl": {product_id: 0.0 for product_id in universe},
+                "max_drawdown_usdc": 0.0,
             },
         )
         row["end_equity"] = cycle.portfolio.equity_usdc
+        running_peak_equity = max(running_peak_equity, cycle.portfolio.equity_usdc)
+        row["max_drawdown_usdc"] = max(
+            float(row["max_drawdown_usdc"]),
+            max(running_peak_equity - cycle.portfolio.equity_usdc, 0.0),
+        )
         max_abs_notional_usdc = cycle.portfolio.equity_usdc * max_leverage
         exposure = (
             abs(cycle.portfolio.gross_notional_usdc / max_abs_notional_usdc)
@@ -263,7 +270,6 @@ def _aggregate_daily_metrics(
 
     ordered_days = sorted(daily_rows)
     previous_end_equity = starting_equity_usdc
-    peak_equity = starting_equity_usdc
     daily_returns: list[SeriesPoint] = []
     daily_turnover: list[SeriesPoint] = []
     daily_exposure: list[SeriesPoint] = []
@@ -281,7 +287,6 @@ def _aggregate_daily_metrics(
             else 0.0
         )
         previous_end_equity = end_equity
-        peak_equity = max(peak_equity, end_equity)
         avg_exposure = (
             sum(row["exposure_points"]) / len(row["exposure_points"])
             if row["exposure_points"]
@@ -290,7 +295,7 @@ def _aggregate_daily_metrics(
         daily_returns.append(SeriesPoint(label=day, value=daily_return))
         daily_turnover.append(SeriesPoint(label=day, value=float(row["turnover_usdc"])))
         daily_exposure.append(SeriesPoint(label=day, value=avg_exposure))
-        daily_drawdown.append(SeriesPoint(label=day, value=max(peak_equity - end_equity, 0.0)))
+        daily_drawdown.append(SeriesPoint(label=day, value=float(row["max_drawdown_usdc"])))
         for product_id in universe:
             asset_contribution_points[product_id].append(
                 SeriesPoint(

--- a/tests/integration/test_sleeve_backtest.py
+++ b/tests/integration/test_sleeve_backtest.py
@@ -44,6 +44,40 @@ def _build_dataset() -> HistoricalDataset:
     )
 
 
+def _build_multiday_dataset() -> HistoricalDataset:
+    anchor = datetime(2026, 3, 20, 23, 55, tzinfo=timezone.utc)
+    candles_by_product = {}
+    for product_id, closes in {
+        "BTC-PERP-INTX": [100.0, 103.0, 106.0, 101.0, 104.0, 108.0, 100.0, 95.0, 102.0, 110.0],
+        "ETH-PERP-INTX": [200.0, 202.0, 204.0, 200.0, 201.0, 205.0, 198.0, 194.0, 199.0, 207.0],
+    }.items():
+        candles = []
+        for index, close in enumerate(closes):
+            candles.append(
+                Candle(
+                    start=anchor + timedelta(minutes=index),
+                    low=close - 1.0,
+                    high=close + 1.0,
+                    open=close,
+                    close=close,
+                    volume=1_000.0,
+                )
+            )
+        candles_by_product[product_id] = tuple(candles)
+    return HistoricalDataset(
+        dataset_id="dataset-sleeve-multiday",
+        created_at=anchor,
+        products=("BTC-PERP-INTX", "ETH-PERP-INTX"),
+        start=anchor,
+        end=anchor + timedelta(minutes=10),
+        granularity="ONE_MINUTE",
+        candles_by_product=candles_by_product,
+        fingerprint="dataset-sleeve-multiday-fingerprint",
+        source="coinbase",
+        version="1",
+    )
+
+
 def test_run_strategy_sleeve_persists_daily_artifacts(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("LOOKBACK_CANDLES", "2")
     monkeypatch.setenv("SIGNAL_SCALE", "200")
@@ -171,3 +205,95 @@ def test_load_strategy_sleeve_analysis_reconstructs_optimizer_inputs(tmp_path, m
         for item in payload["asset_contributions"]
     )
     assert contribution_total == pytest.approx(payload["total_pnl_usdc"])
+
+
+def test_load_strategy_sleeve_analysis_preserves_multiday_drawdown_and_optimizer_inputs(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("LOOKBACK_CANDLES", "2")
+    monkeypatch.setenv("SIGNAL_SCALE", "200")
+    monkeypatch.setenv("REBALANCE_THRESHOLD", "0.0")
+    monkeypatch.setenv("MIN_TRADE_NOTIONAL_USDC", "0.0")
+    monkeypatch.setenv("SLIPPAGE_BPS", "0.0")
+    config = AppConfig.from_env()
+    dataset = _build_multiday_dataset()
+    strategy_instance = StrategyInstanceSpec(
+        strategy_instance_id="mom-multiday",
+        strategy_id="momentum",
+        universe=("BTC-PERP-INTX", "ETH-PERP-INTX"),
+        strategy_params={"lookback_candles": 2, "signal_scale": 200.0},
+        risk_overrides={"max_abs_position": 0.6, "max_gross_position": 1.0},
+    )
+
+    result = run_strategy_sleeve(
+        base_runs_dir=tmp_path,
+        dataset=dataset,
+        config=config,
+        strategy_instance=strategy_instance,
+    )
+
+    payload = load_strategy_sleeve_analysis(result.run_dir)
+    events = [
+        json.loads(line)
+        for line in (result.run_dir / "events.ndjson").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    expected_daily_returns = []
+    expected_daily_drawdowns = []
+    previous_end_equity = config.simulation.starting_collateral_usdc
+    peak_equity = config.simulation.starting_collateral_usdc
+    current_day = None
+    current_day_end_equity = config.simulation.starting_collateral_usdc
+    current_day_max_drawdown = 0.0
+    for event in events:
+        timestamp = datetime.fromisoformat(event["timestamp"])
+        day = timestamp.date().isoformat()
+        equity = float(event["portfolio"]["equity_usdc"])
+        if current_day is None:
+            current_day = day
+        elif day != current_day:
+            expected_daily_returns.append(
+                {
+                    "label": current_day,
+                    "value": (current_day_end_equity / previous_end_equity) - 1.0,
+                }
+            )
+            expected_daily_drawdowns.append(
+                {"label": current_day, "value": current_day_max_drawdown}
+            )
+            previous_end_equity = current_day_end_equity
+            current_day = day
+            current_day_max_drawdown = 0.0
+        peak_equity = max(peak_equity, equity)
+        current_day_max_drawdown = max(current_day_max_drawdown, peak_equity - equity)
+        current_day_end_equity = equity
+
+    assert current_day is not None
+    expected_daily_returns.append(
+        {
+            "label": current_day,
+            "value": (current_day_end_equity / previous_end_equity) - 1.0,
+        }
+    )
+    expected_daily_drawdowns.append(
+        {"label": current_day, "value": current_day_max_drawdown}
+    )
+
+    assert payload["dataset_id"] == dataset.dataset_id
+    assert payload["dataset_fingerprint"] == dataset.fingerprint
+    assert payload["dataset_source"] == dataset.source
+    assert payload["dataset_version"] == dataset.version
+    assert [point["label"] for point in payload["daily_returns"]] == [
+        point["label"] for point in expected_daily_returns
+    ]
+    assert [point["label"] for point in payload["daily_drawdown_usdc"]] == [
+        point["label"] for point in expected_daily_drawdowns
+    ]
+    for actual, expected in zip(payload["daily_returns"], expected_daily_returns, strict=True):
+        assert actual["value"] == pytest.approx(expected["value"])
+    for actual, expected in zip(
+        payload["daily_drawdown_usdc"], expected_daily_drawdowns, strict=True
+    ):
+        assert actual["value"] == pytest.approx(expected["value"])
+    assert payload["daily_drawdown_usdc"][1]["value"] > 0.0

--- a/tests/unit/test_sleeve_backtest_metrics.py
+++ b/tests/unit/test_sleeve_backtest_metrics.py
@@ -1,0 +1,69 @@
+from perpfut.backtest_runner import BacktestAssetCycle, BacktestCycleResult, BacktestPortfolioState
+from perpfut.domain import ExecutionSummary, Mode, PositionState, RiskDecision, SignalDecision
+from perpfut.sleeve_backtest import _aggregate_daily_metrics
+
+
+def _build_cycle(timestamp: str, equity_usdc: float) -> BacktestCycleResult:
+    asset = BacktestAssetCycle(
+        product_id="BTC-PERP-INTX",
+        signal=SignalDecision(strategy="momentum", raw_value=0.1, target_position=0.2),
+        risk_decision=RiskDecision(
+            target_before_risk=0.2,
+            target_after_risk=0.2,
+            current_position=0.0,
+            target_notional_usdc=2_000.0,
+            current_notional_usdc=0.0,
+            delta_notional_usdc=2_000.0,
+            rebalance_threshold=0.0,
+            min_trade_notional_usdc=0.0,
+            halted=False,
+            rebalance_eligible=True,
+        ),
+        execution_summary=ExecutionSummary(
+            action="skipped",
+            reason_code="test",
+            reason_message="test",
+            summary="test",
+        ),
+        no_trade_reason=None,
+        order_intent=None,
+        fill=None,
+        state=PositionState(collateral_usdc=equity_usdc, mark_price=1.0),
+    )
+    return BacktestCycleResult(
+        cycle_id=timestamp,
+        mode=Mode.BACKTEST,
+        timestamp=timestamp,
+        portfolio=BacktestPortfolioState(
+            collateral_usdc=equity_usdc,
+            realized_pnl_usdc=0.0,
+            unrealized_pnl_usdc=0.0,
+            equity_usdc=equity_usdc,
+            gross_notional_usdc=0.0,
+            net_notional_usdc=0.0,
+        ),
+        assets={"BTC-PERP-INTX": asset},
+    )
+
+
+def test_aggregate_daily_metrics_uses_worst_intraday_drawdown() -> None:
+    results = [
+        _build_cycle("2026-03-20T23:57:00+00:00", 10_000.0),
+        _build_cycle("2026-03-20T23:58:00+00:00", 9_500.0),
+        _build_cycle("2026-03-20T23:59:00+00:00", 9_800.0),
+        _build_cycle("2026-03-21T00:00:00+00:00", 10_200.0),
+        _build_cycle("2026-03-21T00:01:00+00:00", 8_700.0),
+        _build_cycle("2026-03-21T00:02:00+00:00", 10_400.0),
+    ]
+
+    daily = _aggregate_daily_metrics(
+        results=results,
+        starting_equity_usdc=10_000.0,
+        max_leverage=2.0,
+        universe=("BTC-PERP-INTX",),
+    )
+
+    assert [(point.label, point.value) for point in daily["drawdown"]] == [
+        ("2026-03-20", 500.0),
+        ("2026-03-21", 1_500.0),
+    ]


### PR DESCRIPTION
Closes #104

## Summary
- compute sleeve daily drawdown from the worst cycle-level drawdown reached within each UTC day
- add a focused unit test for the intraday drawdown aggregation rule
- extend sleeve integration coverage to validate multiday reconstructed optimizer inputs and drawdown series

## Validation
- PYTHONPATH=src python3 -m pytest
- python3 -m ruff check src/perpfut tests

## Notes
- web checks were not rerun in this worktree because local Node tool dependencies are not installed here; GitHub CI will still run the required web job.